### PR TITLE
Add E: Engine<U> type parameter to LTerm and others.

### DIFF
--- a/examples/tree-nodes.rs
+++ b/examples/tree-nodes.rs
@@ -6,11 +6,11 @@ struct TreeNode(LTerm, TreeNode, TreeNode);
 
 // A relation between a tree and a list of its nodes in
 // unnamed form TreeNode(name, left, right)
-fn tree_nodes_unnamed<U: User>(
-    node: TreeNode<U>,
-    d: LTerm<U>,
-    (list, rest): (LTerm<U>, LTerm<U>),
-) -> Goal<U> {
+fn tree_nodes_unnamed<U: User, E: Engine<U>>(
+    node: TreeNode<U, E>,
+    d: LTerm<U, E>,
+    (list, rest): (LTerm<U, E>, LTerm<U, E>),
+) -> Goal<U, E> {
     proto_vulcan_closure!(match node {
         [] => list == rest,
         TreeNode(name, left, right) => |ls0, ls1, ls2| {
@@ -31,11 +31,11 @@ struct NamedNode {
 
 // A relation between a tree and a list of its nodes in
 // named form TreeNode { name, left, right }
-fn tree_nodes_named<U: User>(
-    node: NamedNode<U>,
-    d: LTerm<U>,
-    (list, rest): (LTerm<U>, LTerm<U>),
-) -> Goal<U> {
+fn tree_nodes_named<U: User, E: Engine<U>>(
+    node: NamedNode<U, E>,
+    d: LTerm<U, E>,
+    (list, rest): (LTerm<U, E>, LTerm<U, E>),
+) -> Goal<U, E> {
     proto_vulcan_closure!(match node {
         [] => list == rest,
         NamedNode { name, left, right } => |ls0, ls1, ls2| {
@@ -49,7 +49,7 @@ fn tree_nodes_named<U: User>(
 
 // A relation between a tree and a list of its nodes in
 // untyped form [name, left, right]
-fn tree_nodes<U: User>(node: LTerm<U>, d: LTerm<U>, (list, rest): (LTerm<U>, LTerm<U>)) -> Goal<U> {
+fn tree_nodes<U: User, E: Engine<U>>(node: LTerm<U, E>, d: LTerm<U, E>, (list, rest): (LTerm<U, E>, LTerm<U, E>)) -> Goal<U, E> {
     proto_vulcan_closure!(match node {
         [] => list == rest,
         [name, left, right] => |ls0, ls1, ls2| {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -12,7 +12,7 @@ where
 {
     fn new(context: U::UserContext) -> Self;
 
-    fn start(&self, state: Box<State<U>>, goal: Goal<U, Self>) -> Stream<U, Self>;
+    fn start(&self, state: Box<State<U, Self>>, goal: Goal<U, Self>) -> Stream<U, Self>;
 
     fn step(&self, lazy: Lazy<U, Self>) -> Stream<U, Self>;
 

--- a/src/goal.rs
+++ b/src/goal.rs
@@ -3,12 +3,12 @@ use crate::operator::all::All;
 use crate::operator::any::Any;
 use crate::state::State;
 use crate::stream::Stream;
-use crate::user::{EmptyUser, User};
+use crate::user::{DefaultUser, User};
 use std::fmt;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub enum Goal<U = EmptyUser, E = DefaultEngine<U>>
+pub enum Goal<U = DefaultUser, E = DefaultEngine<U>>
 where
     U: User,
     E: Engine<U>,
@@ -101,18 +101,18 @@ mod test {
     use crate::prelude::*;
     use crate::state::State;
     use crate::stream::Stream;
-    use crate::user::EmptyUser;
+    use crate::user::DefaultUser;
 
     #[test]
     fn test_goal_succeed() {
-        let g = Goal::<EmptyUser>::succeed();
+        let g = Goal::<DefaultUser>::succeed();
         assert!(g.is_succeed());
         assert!(!g.is_fail());
     }
 
     #[test]
     fn test_goal_fail() {
-        let g = Goal::<EmptyUser>::fail();
+        let g = Goal::<DefaultUser>::fail();
         assert!(g.is_fail());
         assert!(!g.is_succeed());
     }
@@ -128,7 +128,7 @@ mod test {
 
     #[test]
     fn test_goal_inner() {
-        let g = Goal::<EmptyUser>::new(TestGoal {});
+        let g = Goal::<DefaultUser>::new(TestGoal {});
         assert!(!g.is_succeed());
         assert!(!g.is_fail());
     }

--- a/src/goal.rs
+++ b/src/goal.rs
@@ -45,7 +45,7 @@ where
         Goal::Fail
     }
 
-    pub fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    pub fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         match self {
             Goal::Succeed => Stream::unit(Box::new(state)),
             Goal::Fail => Stream::empty(),
@@ -91,7 +91,7 @@ where
     E: Engine<U>,
 {
     /// Generate a stream of solutions to the goal by applying it to some initial state.
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E>;
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E>;
 }
 
 #[cfg(test)]
@@ -121,7 +121,7 @@ mod test {
     struct TestGoal {}
 
     impl<E: Engine<U>, U: User> Solve<U, E> for TestGoal {
-        fn solve(&self, _engine: &E, _state: State<U>) -> Stream<U, E> {
+        fn solve(&self, _engine: &E, _state: State<U, E>) -> Stream<U, E> {
             Stream::empty()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@
 //! Proto-vulcan relations are implemented as Rust-functions that have `LTerm`-type
 //! parameters, and `Goal` return value. Because proto-vulcan is parametrized by
 //! generic `User`-type, functions must be made generic with respect to it if we want
-//! to use anything other than the default `EmptyUser`. A simple function example that
+//! to use anything other than the default `DefaultUser`. A simple function example that
 //! implements a relation that succeeds when argument `s` is an empty list is declared as:
 //! ```rust
 //! extern crate proto_vulcan;
@@ -374,7 +374,7 @@ pub mod prelude {
     pub use crate::lterm::LTerm;
     pub use crate::lvalue::LValue;
     pub use crate::state::Constraint;
-    pub use crate::user::{EmptyUser, User};
+    pub use crate::user::{DefaultUser, User};
 
     // conde is the only non-built-in operator exported by default.
     pub use crate::operator::conde::conde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 //! ```rust
 //! # extern crate proto_vulcan;
 //! # use proto_vulcan::prelude::*;
-//! pub fn membero<U: User>(x: LTerm<U>, l: LTerm<U>) -> Goal<U> {
+//! pub fn membero<U: User, E: Engine<U>>(x: LTerm<U, E>, l: LTerm<U, E>) -> Goal<U, E> {
 //!     proto_vulcan_closure!(match l {
 //!         [head | _] => head == x,
 //!         [_ | rest] => membero(x, rest),
@@ -160,7 +160,7 @@
 //! extern crate proto_vulcan;
 //! use proto_vulcan::prelude::*;
 //!
-//! pub fn emptyo<U: User>(s: LTerm<U>) -> Goal<U> {
+//! pub fn emptyo<U: User, E: Engine<U>>(s: LTerm<U, E>) -> Goal<U, E> {
 //!     proto_vulcan!([] == s)
 //! }
 //! # fn main() {}
@@ -337,22 +337,27 @@ pub mod query;
 
 use std::borrow::Borrow;
 use user::User;
+use engine::Engine;
 
-pub trait Upcast<U: User, SuperType>
+pub trait Upcast<U, E, SuperType>
 where
-    Self: CompoundObject<U> + Clone,
-    SuperType: CompoundObject<U>,
+    U: User,
+    E: Engine<U>,
+    Self: CompoundObject<U, E> + Clone,
+    SuperType: CompoundObject<U, E>,
 {
     fn to_super<K: Borrow<Self>>(k: &K) -> SuperType;
 
     fn into_super(self) -> SuperType;
 }
 
-pub trait Downcast<U: User>
+pub trait Downcast<U, E>
 where
-    Self: CompoundObject<U>,
+    U: User,
+    E: Engine<U>,
+    Self: CompoundObject<U, E>,
 {
-    type SubType: CompoundObject<U>;
+    type SubType: CompoundObject<U, E>;
 
     fn into_sub(self) -> Self::SubType;
 }
@@ -364,7 +369,7 @@ pub mod prelude {
     };
 
     pub use crate::compound::CompoundTerm;
-    pub use crate::engine::Engine;
+    pub use crate::engine::{Engine, DefaultEngine};
     pub use crate::goal::{Goal, Solve};
     pub use crate::lterm::LTerm;
     pub use crate::lvalue::LValue;

--- a/src/lresult.rs
+++ b/src/lresult.rs
@@ -1,5 +1,6 @@
 use crate::lterm::{LTerm, LTermInner};
 use crate::lvalue::LValue;
+use crate::engine::Engine;
 use crate::relation::diseq::DisequalityConstraint;
 use crate::state::constraint::store::ConstraintStore;
 use crate::state::constraint::Constraint;
@@ -9,19 +10,23 @@ use std::ops::Deref;
 use std::rc::Rc;
 
 #[derive(Clone, Debug)]
-pub struct LResult<U: User>(pub LTerm<U>, pub Rc<ConstraintStore<U>>);
+pub struct LResult<U: User, E: Engine<U>>(pub LTerm<U, E>, pub Rc<ConstraintStore<U, E>>);
 
-impl<U: User> LResult<U> {
+impl<U, E> LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     /// Check if the wrapped LTerm is an Any-variable with constraints such that it cannot be
     /// the `exception`.
     pub fn is_any_except<T>(&self, exception: &T) -> bool
     where
-        T: PartialEq<LTerm<U>>,
+        T: PartialEq<LTerm<U, E>>,
     {
         if self.0.is_any() {
             // result is an `any` variable, see if it has the expected constraint
             for constraint in self.constraints() {
-                if let Some(tree) = constraint.downcast_ref::<DisequalityConstraint<U>>() {
+                if let Some(tree) = constraint.downcast_ref::<DisequalityConstraint<U, E>>() {
                     for (cu, cv) in tree.smap_ref().iter() {
                         if &self.0 == cu && exception == cv || &self.0 == cv && exception == cu {
                             return true;
@@ -40,21 +45,29 @@ impl<U: User> LResult<U> {
     }
 
     /// Returns iterator to constraints that refer to the wrapped LTerm.
-    pub fn constraints<'a>(&'a self) -> impl Iterator<Item = &'a Rc<dyn Constraint<U>>> {
+    pub fn constraints<'a>(&'a self) -> impl Iterator<Item = &'a Rc<dyn Constraint<U, E>>> {
         let anyvars = self.0.anyvars();
         self.1.relevant(&anyvars)
     }
 }
 
-impl<U: User> Deref for LResult<U> {
-    type Target = LTerm<U>;
+impl<U, E> Deref for LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    type Target = LTerm<U, E>;
 
-    fn deref(&self) -> &LTerm<U> {
+    fn deref(&self) -> &LTerm<U, E> {
         &self.0
     }
 }
 
-impl<U: User> fmt::Display for LResult<U> {
+impl<U, E> fmt::Display for LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)?;
         if self.is_constrained() {
@@ -67,19 +80,31 @@ impl<U: User> fmt::Display for LResult<U> {
     }
 }
 
-impl<U: User> PartialEq<LTerm<U>> for LResult<U> {
-    fn eq(&self, other: &LTerm<U>) -> bool {
+impl<U, E> PartialEq<LTerm<U, E>> for LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LTerm<U, E>) -> bool {
         &self.0 == other
     }
 }
 
-impl<U: User> PartialEq<LResult<U>> for LTerm<U> {
-    fn eq(&self, other: &LResult<U>) -> bool {
+impl<U, E> PartialEq<LResult<U, E>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LResult<U, E>) -> bool {
         &other.0 == self
     }
 }
 
-impl<U: User> PartialEq<LValue> for LResult<U> {
+impl<U, E> PartialEq<LValue> for LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &LValue) -> bool {
         match self.as_ref() {
             LTermInner::Val(v) => v == other,
@@ -88,8 +113,12 @@ impl<U: User> PartialEq<LValue> for LResult<U> {
     }
 }
 
-impl<U: User> PartialEq<LResult<U>> for LValue {
-    fn eq(&self, other: &LResult<U>) -> bool {
+impl<U, E> PartialEq<LResult<U, E>> for LValue
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LResult<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(v) => v == self,
             _ => false,
@@ -97,7 +126,11 @@ impl<U: User> PartialEq<LResult<U>> for LValue {
     }
 }
 
-impl<U: User> PartialEq<bool> for LResult<U> {
+impl<U, E> PartialEq<bool> for LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &bool) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::Bool(x)) => x == other,
@@ -106,8 +139,12 @@ impl<U: User> PartialEq<bool> for LResult<U> {
     }
 }
 
-impl<U: User> PartialEq<LResult<U>> for bool {
-    fn eq(&self, other: &LResult<U>) -> bool {
+impl<U, E> PartialEq<LResult<U, E>> for bool
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LResult<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::Bool(x)) => x == self,
             _ => false,
@@ -115,7 +152,11 @@ impl<U: User> PartialEq<LResult<U>> for bool {
     }
 }
 
-impl<U: User> PartialEq<isize> for LResult<U> {
+impl<U, E> PartialEq<isize> for LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &isize) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::Number(x)) => x == other,
@@ -124,8 +165,12 @@ impl<U: User> PartialEq<isize> for LResult<U> {
     }
 }
 
-impl<U: User> PartialEq<LResult<U>> for isize {
-    fn eq(&self, other: &LResult<U>) -> bool {
+impl<U, E> PartialEq<LResult<U, E>> for isize
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LResult<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::Number(x)) => x == self,
             _ => false,
@@ -133,7 +178,11 @@ impl<U: User> PartialEq<LResult<U>> for isize {
     }
 }
 
-impl<U: User> PartialEq<char> for LResult<U> {
+impl<U, E> PartialEq<char> for LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &char) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::Char(x)) => x == other,
@@ -142,8 +191,12 @@ impl<U: User> PartialEq<char> for LResult<U> {
     }
 }
 
-impl<U: User> PartialEq<LResult<U>> for char {
-    fn eq(&self, other: &LResult<U>) -> bool {
+impl<U, E> PartialEq<LResult<U, E>> for char
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LResult<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::Char(x)) => x == self,
             _ => false,
@@ -151,7 +204,11 @@ impl<U: User> PartialEq<LResult<U>> for char {
     }
 }
 
-impl<U: User> PartialEq<String> for LResult<U> {
+impl<U, E> PartialEq<String> for LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &String) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == other,
@@ -160,8 +217,12 @@ impl<U: User> PartialEq<String> for LResult<U> {
     }
 }
 
-impl<U: User> PartialEq<LResult<U>> for String {
-    fn eq(&self, other: &LResult<U>) -> bool {
+impl<U, E> PartialEq<LResult<U, E>> for String
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LResult<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == self,
             _ => false,
@@ -169,7 +230,11 @@ impl<U: User> PartialEq<LResult<U>> for String {
     }
 }
 
-impl<U: User> PartialEq<&str> for LResult<U> {
+impl<U, E> PartialEq<&str> for LResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &&str) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == other,
@@ -178,8 +243,12 @@ impl<U: User> PartialEq<&str> for LResult<U> {
     }
 }
 
-impl<U: User> PartialEq<LResult<U>> for &str {
-    fn eq(&self, other: &LResult<U>) -> bool {
+impl<U, E> PartialEq<LResult<U, E>> for &str
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LResult<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == self,
             _ => false,

--- a/src/lterm.rs
+++ b/src/lterm.rs
@@ -1,5 +1,5 @@
 use crate::compound::CompoundObject;
-use crate::user::{EmptyUser, User};
+use crate::user::{DefaultUser, User};
 use crate::engine::{Engine, DefaultEngine};
 use std::borrow::Borrow;
 use std::fmt;
@@ -64,7 +64,7 @@ where
 
 #[derive(Derivative)]
 #[derivative(Clone(bound="U: User"))]
-pub struct LTerm<U = EmptyUser, E = DefaultEngine<U>>
+pub struct LTerm<U = DefaultUser, E = DefaultEngine<U>>
 where
     U: User,
     E: Engine<U>,
@@ -1029,7 +1029,7 @@ mod test {
 
     #[test]
     fn test_lterm_var_1() {
-        let mut u = LTerm::<EmptyUser>::var("x");
+        let mut u = LTerm::<DefaultUser>::var("x");
         assert!(u.is_var());
         assert!(!u.is_val());
         assert!(!u.is_bool());
@@ -1047,12 +1047,12 @@ mod test {
     #[test]
     #[should_panic]
     fn test_lterm_var_2() {
-        let _ = LTerm::<EmptyUser>::var("_");
+        let _ = LTerm::<DefaultUser>::var("_");
     }
 
     #[test]
     fn test_lterm_val_1() {
-        let mut u: LTerm<EmptyUser, DefaultEngine<EmptyUser>> = lterm!(1);
+        let mut u: LTerm<DefaultUser, DefaultEngine<DefaultUser>> = lterm!(1);
         assert!(u.is_val());
         assert!(!u.is_var());
         assert!(!u.is_bool());
@@ -1069,7 +1069,7 @@ mod test {
 
     #[test]
     fn test_lterm_val_2() {
-        let mut u: LTerm<EmptyUser> = lterm!(true);
+        let mut u: LTerm<DefaultUser> = lterm!(true);
         assert!(u.is_val());
         assert!(!u.is_var());
         assert!(u.is_bool());
@@ -1086,14 +1086,14 @@ mod test {
 
     #[test]
     fn test_lterm_iter_1() {
-        let u: LTerm<EmptyUser> = lterm!([]);
+        let u: LTerm<DefaultUser> = lterm!([]);
         let mut iter = u.iter();
         assert!(iter.next().is_none());
     }
 
     #[test]
     fn test_lterm_iter_2() {
-        let u: LTerm<EmptyUser> = lterm!([1]);
+        let u: LTerm<DefaultUser> = lterm!([1]);
         let mut iter = u.iter();
         assert_eq!(iter.next().unwrap(), &1);
         assert!(iter.next().is_none());
@@ -1101,7 +1101,7 @@ mod test {
 
     #[test]
     fn test_lterm_iter_3() {
-        let u: LTerm<EmptyUser> = lterm!([1, 2, 3]);
+        let u: LTerm<DefaultUser> = lterm!([1, 2, 3]);
         let mut iter = u.iter();
         assert_eq!(iter.next().unwrap(), &1);
         assert_eq!(iter.next().unwrap(), &2);
@@ -1111,7 +1111,7 @@ mod test {
 
     #[test]
     fn test_lterm_iter_4() {
-        let u: LTerm<EmptyUser> = lterm!([1, 2 | 3]);
+        let u: LTerm<DefaultUser> = lterm!([1, 2 | 3]);
         let mut iter = u.iter();
         assert_eq!(iter.next().unwrap(), &1);
         assert_eq!(iter.next().unwrap(), &2);
@@ -1121,7 +1121,7 @@ mod test {
 
     #[test]
     fn test_lterm_iter_5() {
-        let u: LTerm<EmptyUser> = lterm!([1, 2, 3]);
+        let u: LTerm<DefaultUser> = lterm!([1, 2, 3]);
         let mut iter = IntoIterator::into_iter(&u);
         assert_eq!(iter.next().unwrap(), &1);
         assert_eq!(iter.next().unwrap(), &2);
@@ -1131,7 +1131,7 @@ mod test {
 
     #[test]
     fn test_lterm_iter_mut_1() {
-        let mut u: LTerm<EmptyUser> = lterm!([1, 2, 3]);
+        let mut u: LTerm<DefaultUser> = lterm!([1, 2, 3]);
         let iter = u.iter_mut();
         for x in iter {
             *x = lterm!(4);
@@ -1145,7 +1145,7 @@ mod test {
 
     #[test]
     fn test_lterm_iter_mut_2() {
-        let mut u: LTerm<EmptyUser> = lterm!([1, 2, 3]);
+        let mut u: LTerm<DefaultUser> = lterm!([1, 2, 3]);
         for term in &mut u {
             *term = lterm!(5);
         }
@@ -1158,15 +1158,15 @@ mod test {
 
     #[test]
     fn test_lterm_from_iter_1() {
-        let v: Vec<LTerm<EmptyUser>> = vec![lterm!(1), lterm!(2), lterm!(3)];
-        let u: LTerm<EmptyUser> = LTerm::from_iter(v);
+        let v: Vec<LTerm<DefaultUser>> = vec![lterm!(1), lterm!(2), lterm!(3)];
+        let u: LTerm<DefaultUser> = LTerm::from_iter(v);
         assert!(u == lterm!([1, 2, 3]));
     }
 
     #[test]
     fn test_lterm_extend_1() {
         let v = vec![lterm!(1), lterm!(2), lterm!(3)];
-        let mut u: LTerm<EmptyUser> = lterm!([]);
+        let mut u: LTerm<DefaultUser> = lterm!([]);
         u.extend(v);
         assert!(u == lterm!([1, 2, 3]));
     }
@@ -1174,7 +1174,7 @@ mod test {
     #[test]
     fn test_lterm_extend_2() {
         let v = vec![lterm!(1), lterm!(2), lterm!(3)];
-        let mut u: LTerm<EmptyUser> = lterm!([4, 5, 6]);
+        let mut u: LTerm<DefaultUser> = lterm!([4, 5, 6]);
         u.extend(v);
         assert!(u == lterm!([4, 5, 6, 1, 2, 3]));
     }
@@ -1182,19 +1182,19 @@ mod test {
     #[test]
     fn test_lterm_eq_1() {
         // LTerm vs. LTerm
-        assert_eq!(lterm!(1) as LTerm<EmptyUser>, lterm!(1));
-        assert_eq!(lterm!(true) as LTerm<EmptyUser>, lterm!(true));
-        assert_eq!(lterm!("foo") as LTerm<EmptyUser>, lterm!("foo"));
-        assert_eq!(lterm!('a') as LTerm<EmptyUser>, lterm!('a'));
-        assert_eq!(lterm!([1, 2, 3]) as LTerm<EmptyUser>, lterm!([1, 2, 3]));
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, lterm!(2));
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, lterm!(true));
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, lterm!('a'));
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, lterm!([]));
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, lterm!([1]));
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, lterm!("true"));
-        let u: LTerm<EmptyUser> = LTerm::var("x");
-        let v: LTerm<EmptyUser> = LTerm::var("x");
+        assert_eq!(lterm!(1) as LTerm<DefaultUser>, lterm!(1));
+        assert_eq!(lterm!(true) as LTerm<DefaultUser>, lterm!(true));
+        assert_eq!(lterm!("foo") as LTerm<DefaultUser>, lterm!("foo"));
+        assert_eq!(lterm!('a') as LTerm<DefaultUser>, lterm!('a'));
+        assert_eq!(lterm!([1, 2, 3]) as LTerm<DefaultUser>, lterm!([1, 2, 3]));
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, lterm!(2));
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, lterm!(true));
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, lterm!('a'));
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, lterm!([]));
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, lterm!([1]));
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, lterm!("true"));
+        let u: LTerm<DefaultUser> = LTerm::var("x");
+        let v: LTerm<DefaultUser> = LTerm::var("x");
         assert_eq!(u, u);
         assert_ne!(u, v);
     }
@@ -1202,72 +1202,72 @@ mod test {
     #[test]
     fn test_lterm_eq_2() {
         // LTerm vs. Rust constant
-        assert_eq!(lterm!(1) as LTerm<EmptyUser>, 1);
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, 2);
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, true);
-        assert_eq!(1, lterm!(1) as LTerm<EmptyUser>);
-        assert_ne!(2, lterm!(1) as LTerm<EmptyUser>);
-        assert_ne!(true, lterm!(1) as LTerm<EmptyUser>);
-        assert_eq!(lterm!("proto-vulcan") as LTerm<EmptyUser>, "proto-vulcan");
-        assert_ne!(lterm!(["proto-vulcan"]) as LTerm<EmptyUser>, "proto-vulcan");
-        assert_eq!("proto-vulcan", lterm!("proto-vulcan") as LTerm<EmptyUser>);
-        assert_ne!("proto-vulcan", lterm!(["proto-vulcan"]) as LTerm<EmptyUser>);
+        assert_eq!(lterm!(1) as LTerm<DefaultUser>, 1);
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, 2);
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, true);
+        assert_eq!(1, lterm!(1) as LTerm<DefaultUser>);
+        assert_ne!(2, lterm!(1) as LTerm<DefaultUser>);
+        assert_ne!(true, lterm!(1) as LTerm<DefaultUser>);
+        assert_eq!(lterm!("proto-vulcan") as LTerm<DefaultUser>, "proto-vulcan");
+        assert_ne!(lterm!(["proto-vulcan"]) as LTerm<DefaultUser>, "proto-vulcan");
+        assert_eq!("proto-vulcan", lterm!("proto-vulcan") as LTerm<DefaultUser>);
+        assert_ne!("proto-vulcan", lterm!(["proto-vulcan"]) as LTerm<DefaultUser>);
         assert_eq!(
-            lterm!("proto-vulcan") as LTerm<EmptyUser>,
+            lterm!("proto-vulcan") as LTerm<DefaultUser>,
             "proto-vulcan"[0..]
         );
         assert_ne!(
-            lterm!(["proto-vulcan"]) as LTerm<EmptyUser>,
+            lterm!(["proto-vulcan"]) as LTerm<DefaultUser>,
             "proto-vulcan"[0..]
         );
         assert_eq!(
             "proto-vulcan"[0..],
-            lterm!("proto-vulcan") as LTerm<EmptyUser>
+            lterm!("proto-vulcan") as LTerm<DefaultUser>
         );
         assert_ne!(
             "proto-vulcan"[0..],
-            lterm!(["proto-vulcan"]) as LTerm<EmptyUser>
+            lterm!(["proto-vulcan"]) as LTerm<DefaultUser>
         );
         assert_eq!(
-            lterm!("proto-vulcan") as LTerm<EmptyUser>,
+            lterm!("proto-vulcan") as LTerm<DefaultUser>,
             String::from("proto-vulcan")
         );
         assert_ne!(
-            lterm!(["proto-vulcan"]) as LTerm<EmptyUser>,
+            lterm!(["proto-vulcan"]) as LTerm<DefaultUser>,
             String::from("proto-vulcan")
         );
         assert_eq!(
             String::from("proto-vulcan"),
-            lterm!("proto-vulcan") as LTerm<EmptyUser>
+            lterm!("proto-vulcan") as LTerm<DefaultUser>
         );
         assert_ne!(
             String::from("proto-vulcan"),
-            lterm!(["proto-vulcan"]) as LTerm<EmptyUser>
+            lterm!(["proto-vulcan"]) as LTerm<DefaultUser>
         );
-        assert_eq!(lterm!('a') as LTerm<EmptyUser>, 'a');
-        assert_ne!('b', lterm!('a') as LTerm<EmptyUser>);
-        assert_ne!(lterm!(['a']) as LTerm<EmptyUser>, 'a');
-        assert_ne!('a', lterm!(['a']) as LTerm<EmptyUser>);
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, lterm!([1]));
-        assert_ne!(lterm!([1]), lterm!(1) as LTerm<EmptyUser>);
+        assert_eq!(lterm!('a') as LTerm<DefaultUser>, 'a');
+        assert_ne!('b', lterm!('a') as LTerm<DefaultUser>);
+        assert_ne!(lterm!(['a']) as LTerm<DefaultUser>, 'a');
+        assert_ne!('a', lterm!(['a']) as LTerm<DefaultUser>);
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, lterm!([1]));
+        assert_ne!(lterm!([1]), lterm!(1) as LTerm<DefaultUser>);
     }
 
     #[test]
     fn test_lterm_eq_3() {
         // LTerm vs. LValue
-        assert_eq!(lterm!(1) as LTerm<EmptyUser>, LValue::from(1));
-        assert_ne!(lterm!(1) as LTerm<EmptyUser>, LValue::from(2));
-        assert_eq!(LValue::from(1), lterm!(1) as LTerm<EmptyUser>);
-        assert_ne!(LValue::from(2), lterm!(1) as LTerm<EmptyUser>);
-        assert_ne!(LValue::from(1), lterm!([1]) as LTerm<EmptyUser>);
-        assert_ne!(lterm!([1]) as LTerm<EmptyUser>, LValue::from(1));
+        assert_eq!(lterm!(1) as LTerm<DefaultUser>, LValue::from(1));
+        assert_ne!(lterm!(1) as LTerm<DefaultUser>, LValue::from(2));
+        assert_eq!(LValue::from(1), lterm!(1) as LTerm<DefaultUser>);
+        assert_ne!(LValue::from(2), lterm!(1) as LTerm<DefaultUser>);
+        assert_ne!(LValue::from(1), lterm!([1]) as LTerm<DefaultUser>);
+        assert_ne!(lterm!([1]) as LTerm<DefaultUser>, LValue::from(1));
     }
 
     #[test]
     #[should_panic]
     fn test_lterm_projection_1() {
         // Comparison with projection panics
-        let u: LTerm<EmptyUser> = LTerm::var("x");
+        let u: LTerm<DefaultUser> = LTerm::var("x");
         let v = LTerm::projection(u.clone());
         assert_eq!(u, v);
     }
@@ -1276,7 +1276,7 @@ mod test {
     #[should_panic]
     fn test_lterm_projection_2() {
         // Comparison with projection panics
-        let u: LTerm<EmptyUser> = LTerm::var("x");
+        let u: LTerm<DefaultUser> = LTerm::var("x");
         let v = LTerm::projection(u.clone());
         assert_eq!(v, u);
     }
@@ -1286,14 +1286,14 @@ mod test {
     fn test_lterm_projection_3() {
         // Hash of projection panics
         let mut t = HashMap::new();
-        let u: LTerm<EmptyUser> = LTerm::var("x");
+        let u: LTerm<DefaultUser> = LTerm::var("x");
         let v = LTerm::projection(u.clone());
-        t.insert(v, lterm!(1) as LTerm<EmptyUser>);
+        t.insert(v, lterm!(1) as LTerm<DefaultUser>);
     }
 
     #[test]
     fn test_lterm_index_1() {
-        let u: LTerm<EmptyUser> = lterm!([1, [2], false]);
+        let u: LTerm<DefaultUser> = lterm!([1, [2], false]);
         assert_eq!(u[0], 1);
         assert_eq!(u[1], lterm!([2]));
         assert_eq!(u[2], false);
@@ -1301,7 +1301,7 @@ mod test {
 
     #[test]
     fn test_lterm_index_mut_1() {
-        let mut u: LTerm<EmptyUser> = lterm!([0, 0, 0]);
+        let mut u: LTerm<DefaultUser> = lterm!([0, 0, 0]);
         u[0] = lterm!(1);
         u[1] = lterm!([2]);
         u[2] = lterm!(false);
@@ -1312,23 +1312,23 @@ mod test {
 
     #[test]
     fn test_lterm_display() {
-        assert_eq!(format!("{}", lterm!(1234) as LTerm<EmptyUser>), "1234");
-        assert_eq!(format!("{}", lterm!(-1234) as LTerm<EmptyUser>), "-1234");
-        assert_eq!(format!("{}", lterm!(true) as LTerm<EmptyUser>), "true");
-        assert_eq!(format!("{}", lterm!(false) as LTerm<EmptyUser>), "false");
-        assert_eq!(format!("{}", LTerm::var("x") as LTerm<EmptyUser>), "x");
-        assert_eq!(format!("{}", lterm!([]) as LTerm<EmptyUser>), "[]");
+        assert_eq!(format!("{}", lterm!(1234) as LTerm<DefaultUser>), "1234");
+        assert_eq!(format!("{}", lterm!(-1234) as LTerm<DefaultUser>), "-1234");
+        assert_eq!(format!("{}", lterm!(true) as LTerm<DefaultUser>), "true");
+        assert_eq!(format!("{}", lterm!(false) as LTerm<DefaultUser>), "false");
+        assert_eq!(format!("{}", LTerm::var("x") as LTerm<DefaultUser>), "x");
+        assert_eq!(format!("{}", lterm!([]) as LTerm<DefaultUser>), "[]");
         assert_eq!(
-            format!("{}", lterm!([1, [2], true, 'a']) as LTerm<EmptyUser>),
+            format!("{}", lterm!([1, [2], true, 'a']) as LTerm<DefaultUser>),
             "[1, [2], true, 'a']"
         );
         assert_eq!(
-            format!("{}", lterm!([1, 2 | 3]) as LTerm<EmptyUser>),
+            format!("{}", lterm!([1, 2 | 3]) as LTerm<DefaultUser>),
             "[1, 2 | 3]"
         );
         let u = LTerm::var("x");
         assert_eq!(
-            format!("{}", LTerm::projection(u) as LTerm<EmptyUser>),
+            format!("{}", LTerm::projection(u) as LTerm<DefaultUser>),
             "Projection(x)"
         );
     }

--- a/src/lterm.rs
+++ b/src/lterm.rs
@@ -1,5 +1,6 @@
 use crate::compound::CompoundObject;
 use crate::user::{EmptyUser, User};
+use crate::engine::{Engine, DefaultEngine};
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -30,10 +31,12 @@ impl fmt::Display for VarID {
 }
 
 /// Logic Term.
-#[derive(Clone, Debug)]
-pub enum LTermInner<U = EmptyUser>
+#[derive(Derivative, Debug)]
+#[derivative(Clone(bound="U: User"))]
+pub enum LTermInner<U, E>
 where
     U: User,
+    E: Engine<U>,
 {
     /// Literal value
     Val(LValue),
@@ -48,31 +51,37 @@ where
     Empty,
 
     /// Non-empty list
-    Cons(LTerm<U>, LTerm<U>),
+    Cons(LTerm<U, E>, LTerm<U, E>),
 
     // Projection variable. A Projection variable will cause panic if it is tested for equality
     // or a hash is computed. To use in substitutions, it must be projected first to non-Projection
     // kind LTerm.
-    Projection(LTerm<U>),
+    Projection(LTerm<U, E>),
 
     // Compound object
-    Compound(Rc<dyn CompoundObject<U>>),
+    Compound(Rc<dyn CompoundObject<U, E>>),
 }
 
-#[derive(Clone)]
-pub struct LTerm<U = EmptyUser>
+#[derive(Derivative)]
+#[derivative(Clone(bound="U: User"))]
+pub struct LTerm<U = EmptyUser, E = DefaultEngine<U>>
 where
     U: User,
+    E: Engine<U>,
 {
-    inner: Rc<LTermInner<U>>,
+    inner: Rc<LTermInner<U, E>>,
 }
 
-impl<U: User> LTerm<U> {
-    pub fn ptr_eq(this: &LTerm<U>, other: &LTerm<U>) -> bool {
+impl<U, E> LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn ptr_eq(this: &LTerm<U, E>, other: &LTerm<U, E>) -> bool {
         Rc::ptr_eq(&this.inner, &other.inner)
     }
 
-    pub fn var(name: &'static str) -> LTerm<U> {
+    pub fn var(name: &'static str) -> LTerm<U, E> {
         if name == "_" {
             panic!("Error: Invalid variable name. Name \"_\" is reserved for any-variables.")
         }
@@ -82,13 +91,13 @@ impl<U: User> LTerm<U> {
         }
     }
 
-    pub fn any() -> LTerm<U> {
+    pub fn any() -> LTerm<U, E> {
         LTerm {
             inner: Rc::new(LTermInner::Var(VarID::new(), "_")),
         }
     }
 
-    pub fn user(u: U::UserTerm) -> LTerm<U> {
+    pub fn user(u: U::UserTerm) -> LTerm<U, E> {
         LTerm {
             inner: Rc::new(LTermInner::User(u)),
         }
@@ -96,7 +105,7 @@ impl<U: User> LTerm<U> {
 
     /// Constructs an empty list
     ///
-    pub fn empty_list() -> LTerm<U> {
+    pub fn empty_list() -> LTerm<U, E> {
         LTerm {
             inner: Rc::new(LTermInner::Empty),
         }
@@ -104,13 +113,13 @@ impl<U: User> LTerm<U> {
 
     /// Constructs a LTerm list with a single element
     ///
-    pub fn singleton(u: LTerm<U>) -> LTerm<U> {
+    pub fn singleton(u: LTerm<U, E>) -> LTerm<U, E> {
         LTerm {
             inner: Rc::new(LTermInner::Cons(u, LTerm::empty_list())),
         }
     }
 
-    pub fn projection(u: LTerm<U>) -> LTerm<U> {
+    pub fn projection(u: LTerm<U, E>) -> LTerm<U, E> {
         match u.as_ref() {
             LTermInner::Var(_, _) => LTerm {
                 inner: Rc::new(LTermInner::Projection(u)),
@@ -123,14 +132,14 @@ impl<U: User> LTerm<U> {
     /// that is applied to the projection variable.
     pub fn project<F>(&self, f: F)
     where
-        F: FnOnce(&LTerm<U>) -> LTerm<U>,
+        F: FnOnce(&LTerm<U, E>) -> LTerm<U, E>,
     {
         match self.as_ref() {
             LTermInner::Projection(p) => {
-                let ptr: *const LTermInner<U> = self.inner.as_ref();
+                let ptr: *const LTermInner<U, E> = self.inner.as_ref();
                 let projected = f(p).into_inner();
                 let _ = unsafe {
-                    let mut_ptr = ptr as *mut LTermInner<U>;
+                    let mut_ptr = ptr as *mut LTermInner<U, E>;
                     std::ptr::replace(mut_ptr, projected.as_ref().clone())
                 };
             }
@@ -138,18 +147,18 @@ impl<U: User> LTerm<U> {
         }
     }
 
-    pub fn into_inner(self) -> Rc<LTermInner<U>> {
+    pub fn into_inner(self) -> Rc<LTermInner<U, E>> {
         self.inner
     }
 
     /// Construct a list cell
-    pub fn cons(head: LTerm<U>, tail: LTerm<U>) -> LTerm<U> {
+    pub fn cons(head: LTerm<U, E>, tail: LTerm<U, E>) -> LTerm<U, E> {
         LTerm {
             inner: Rc::new(LTermInner::Cons(head, tail)),
         }
     }
 
-    pub fn from_vec(l: Vec<LTerm<U>>) -> LTerm<U> {
+    pub fn from_vec(l: Vec<LTerm<U, E>>) -> LTerm<U, E> {
         if l.is_empty() {
             LTerm::empty_list()
         } else {
@@ -161,7 +170,7 @@ impl<U: User> LTerm<U> {
         }
     }
 
-    pub fn from_array(a: &[LTerm<U>]) -> LTerm<U> {
+    pub fn from_array(a: &[LTerm<U, E>]) -> LTerm<U, E> {
         if a.is_empty() {
             LTerm::empty_list()
         } else {
@@ -173,7 +182,7 @@ impl<U: User> LTerm<U> {
         }
     }
 
-    pub fn improper_from_vec(mut h: Vec<LTerm<U>>) -> LTerm<U> {
+    pub fn improper_from_vec(mut h: Vec<LTerm<U, E>>) -> LTerm<U, E> {
         if h.is_empty() {
             panic!("Improper list must have at least one element");
         } else {
@@ -185,7 +194,7 @@ impl<U: User> LTerm<U> {
         }
     }
 
-    pub fn improper_from_array(h: &[LTerm<U>]) -> LTerm<U> {
+    pub fn improper_from_array(h: &[LTerm<U, E>]) -> LTerm<U, E> {
         let mut h = h.to_vec();
         if h.is_empty() {
             panic!("Improper list must have at least one element");
@@ -198,7 +207,7 @@ impl<U: User> LTerm<U> {
         }
     }
 
-    pub fn contains<T: Borrow<LTerm<U>>>(&self, v: &T) -> bool {
+    pub fn contains<T: Borrow<LTerm<U, E>>>(&self, v: &T) -> bool {
         let v = v.borrow();
         self.iter().any(|u| u == v)
     }
@@ -240,7 +249,7 @@ impl<U: User> LTerm<U> {
 
     pub fn is_var(&self) -> bool {
         match self.as_ref() {
-            LTermInner::<U>::Var(_, _) => true,
+            LTermInner::<U, E>::Var(_, _) => true,
             _ => false,
         }
     }
@@ -273,7 +282,7 @@ impl<U: User> LTerm<U> {
         }
     }
 
-    pub fn get_projection(&self) -> Option<&LTerm<U>> {
+    pub fn get_projection(&self) -> Option<&LTerm<U, E>> {
         match self.as_ref() {
             LTermInner::Projection(p) => Some(p),
             _ => None,
@@ -320,44 +329,44 @@ impl<U: User> LTerm<U> {
         }
     }
 
-    pub fn head(&self) -> Option<&LTerm<U>> {
+    pub fn head(&self) -> Option<&LTerm<U, E>> {
         match self.as_ref() {
             LTermInner::Cons(head, _) => Some(head),
             _ => None,
         }
     }
 
-    pub fn tail(&self) -> Option<&LTerm<U>> {
+    pub fn tail(&self) -> Option<&LTerm<U, E>> {
         match self.as_ref() {
             LTermInner::Cons(_, tail) => Some(tail),
             _ => None,
         }
     }
 
-    pub fn head_mut(&mut self) -> Option<&mut LTerm<U>> {
+    pub fn head_mut(&mut self) -> Option<&mut LTerm<U, E>> {
         match self.as_mut() {
             LTermInner::Cons(head, _) => Some(head),
             _ => None,
         }
     }
 
-    pub fn tail_mut(&mut self) -> Option<&mut LTerm<U>> {
+    pub fn tail_mut(&mut self) -> Option<&mut LTerm<U, E>> {
         match self.as_mut() {
             LTermInner::Cons(_, tail) => Some(tail),
             _ => None,
         }
     }
 
-    pub fn iter(&self) -> LTermIter<'_, U> {
+    pub fn iter(&self) -> LTermIter<'_, U, E> {
         LTermIter::new(self)
     }
 
-    pub fn iter_mut(&mut self) -> LTermIterMut<'_, U> {
+    pub fn iter_mut(&mut self) -> LTermIterMut<'_, U, E> {
         LTermIterMut::new(self)
     }
 
     /// Recursively find all `any` variables referenced by the LTerm.
-    pub fn anyvars(self: &LTerm<U>) -> Vec<LTerm<U>> {
+    pub fn anyvars(self: &LTerm<U, E>) -> Vec<LTerm<U, E>> {
         match self.as_ref() {
             LTermInner::Cons(head, tail) => {
                 let mut vars = head.anyvars();
@@ -378,75 +387,123 @@ impl<U: User> LTerm<U> {
     }
 }
 
-impl<U: User> From<Rc<dyn CompoundObject<U>>> for LTerm<U> {
-    fn from(u: Rc<dyn CompoundObject<U>>) -> LTerm<U> {
+impl<U, E> From<Rc<dyn CompoundObject<U, E>>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn from(u: Rc<dyn CompoundObject<U, E>>) -> LTerm<U, E> {
         LTerm::from(LTermInner::Compound(u))
     }
 }
 
-impl<U: User> From<&LTerm<U>> for LTerm<U> {
-    fn from(reference: &LTerm<U>) -> LTerm<U> {
+impl<U, E> From<&LTerm<U, E>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn from(reference: &LTerm<U, E>) -> LTerm<U, E> {
         reference.clone()
     }
 }
 
-impl<U: User> From<LTermInner<U>> for LTerm<U> {
-    fn from(inner: LTermInner<U>) -> LTerm<U> {
+impl<U, E> From<LTermInner<U, E>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn from(inner: LTermInner<U, E>) -> LTerm<U, E> {
         LTerm {
             inner: Rc::new(inner),
         }
     }
 }
 
-impl<U: User> From<isize> for LTerm<U> {
-    fn from(u: isize) -> LTerm<U> {
+impl<U, E> From<isize> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn from(u: isize) -> LTerm<U, E> {
         LTerm::from(LTermInner::Val(LValue::Number(u)))
     }
 }
 
-impl<U: User> From<bool> for LTerm<U> {
-    fn from(u: bool) -> LTerm<U> {
+impl<U, E> From<bool> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn from(u: bool) -> LTerm<U, E> {
         LTerm::from(LTermInner::Val(LValue::Bool(u)))
     }
 }
 
-impl<U: User> From<&str> for LTerm<U> {
-    fn from(u: &str) -> LTerm<U> {
+impl<U, E> From<&str> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn from(u: &str) -> LTerm<U, E> {
         LTerm::from(LTermInner::Val(LValue::String(String::from(u))))
     }
 }
 
-impl<U: User> From<String> for LTerm<U> {
-    fn from(u: String) -> LTerm<U> {
+impl<U, E> From<String> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn from(u: String) -> LTerm<U, E> {
         LTerm::from(LTermInner::Val(LValue::String(u)))
     }
 }
 
-impl<U: User> From<char> for LTerm<U> {
-    fn from(u: char) -> LTerm<U> {
+impl<U, E> From<char> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn from(u: char) -> LTerm<U, E> {
         LTerm::from(LTermInner::Val(LValue::Char(u)))
     }
 }
 
-impl<U: User> AsRef<LTermInner<U>> for LTerm<U> {
-    fn as_ref(&self) -> &LTermInner<U> {
+impl<U, E> AsRef<LTermInner<U, E>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn as_ref(&self) -> &LTermInner<U, E> {
         &self.inner
     }
 }
 
-impl<U: User> AsRef<LTerm<U>> for LTerm<U> {
-    fn as_ref(&self) -> &LTerm<U> {
+impl<U, E> AsRef<LTerm<U, E>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn as_ref(&self) -> &LTerm<U, E> {
         self
     }
 }
 
-impl<U: User> AsMut<LTermInner<U>> for LTerm<U> {
-    fn as_mut(&mut self) -> &mut LTermInner<U> {
+impl<U, E> AsMut<LTermInner<U, E>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn as_mut(&mut self) -> &mut LTermInner<U, E> {
         Rc::make_mut(&mut self.inner)
     }
 }
 
-impl<U: User> fmt::Debug for LTerm<U> {
+impl<U, E> fmt::Debug for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.as_ref() {
             LTermInner::Val(val) => write!(f, "{:?}", val),
@@ -460,7 +517,11 @@ impl<U: User> fmt::Debug for LTerm<U> {
     }
 }
 
-impl<U: User> fmt::Display for LTerm<U> {
+impl<U, E> fmt::Display for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.as_ref() {
             LTermInner::Val(val) => write!(f, "{}", val),
@@ -505,7 +566,11 @@ impl<U: User> fmt::Display for LTerm<U> {
     }
 }
 
-impl<U: User> Hash for LTerm<U> {
+impl<U, E> Hash for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self.as_ref() {
             LTermInner::Val(val) => val.hash(state),
@@ -522,7 +587,11 @@ impl<U: User> Hash for LTerm<U> {
     }
 }
 
-impl<U: User> PartialEq<LTerm<U>> for LTerm<U> {
+impl<U, E> PartialEq<LTerm<U, E>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &Self) -> bool {
         match (self.as_ref(), other.as_ref()) {
             (LTermInner::Var(self_uid, _), LTermInner::Var(other_uid, _)) => self_uid == other_uid,
@@ -542,7 +611,11 @@ impl<U: User> PartialEq<LTerm<U>> for LTerm<U> {
     }
 }
 
-impl<U: User> PartialEq<LValue> for LTerm<U> {
+impl<U, E> PartialEq<LValue> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &LValue) -> bool {
         match self.as_ref() {
             LTermInner::Val(v) => v == other,
@@ -551,8 +624,12 @@ impl<U: User> PartialEq<LValue> for LTerm<U> {
     }
 }
 
-impl<U: User> PartialEq<LTerm<U>> for LValue {
-    fn eq(&self, other: &LTerm<U>) -> bool {
+impl<U, E> PartialEq<LTerm<U, E>> for LValue
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LTerm<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(v) => v == self,
             _ => false,
@@ -560,7 +637,11 @@ impl<U: User> PartialEq<LTerm<U>> for LValue {
     }
 }
 
-impl<U: User> PartialEq<bool> for LTerm<U> {
+impl<U, E> PartialEq<bool> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &bool) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::Bool(x)) => x == other,
@@ -569,8 +650,12 @@ impl<U: User> PartialEq<bool> for LTerm<U> {
     }
 }
 
-impl<U: User> PartialEq<LTerm<U>> for bool {
-    fn eq(&self, other: &LTerm<U>) -> bool {
+impl<U, E> PartialEq<LTerm<U, E>> for bool
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LTerm<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::Bool(x)) => x == self,
             _ => false,
@@ -578,7 +663,11 @@ impl<U: User> PartialEq<LTerm<U>> for bool {
     }
 }
 
-impl<U: User> PartialEq<isize> for LTerm<U> {
+impl<U, E> PartialEq<isize> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &isize) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::Number(x)) => x == other,
@@ -587,8 +676,12 @@ impl<U: User> PartialEq<isize> for LTerm<U> {
     }
 }
 
-impl<U: User> PartialEq<LTerm<U>> for isize {
-    fn eq(&self, other: &LTerm<U>) -> bool {
+impl<U, E> PartialEq<LTerm<U, E>> for isize
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LTerm<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::Number(x)) => x == self,
             _ => false,
@@ -596,7 +689,11 @@ impl<U: User> PartialEq<LTerm<U>> for isize {
     }
 }
 
-impl<U: User> PartialEq<char> for LTerm<U> {
+impl<U, E> PartialEq<char> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &char) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::Char(x)) => x == other,
@@ -605,8 +702,12 @@ impl<U: User> PartialEq<char> for LTerm<U> {
     }
 }
 
-impl<U: User> PartialEq<LTerm<U>> for char {
-    fn eq(&self, other: &LTerm<U>) -> bool {
+impl<U, E> PartialEq<LTerm<U, E>> for char
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LTerm<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::Char(x)) => x == self,
             _ => false,
@@ -614,7 +715,11 @@ impl<U: User> PartialEq<LTerm<U>> for char {
     }
 }
 
-impl<U: User> PartialEq<String> for LTerm<U> {
+impl<U, E> PartialEq<String> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &String) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == other,
@@ -623,8 +728,12 @@ impl<U: User> PartialEq<String> for LTerm<U> {
     }
 }
 
-impl<U: User> PartialEq<LTerm<U>> for String {
-    fn eq(&self, other: &LTerm<U>) -> bool {
+impl<U, E> PartialEq<LTerm<U, E>> for String
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LTerm<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == self,
             _ => false,
@@ -632,7 +741,11 @@ impl<U: User> PartialEq<LTerm<U>> for String {
     }
 }
 
-impl<U: User> PartialEq<str> for LTerm<U> {
+impl<U, E> PartialEq<str> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &str) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == other,
@@ -641,8 +754,12 @@ impl<U: User> PartialEq<str> for LTerm<U> {
     }
 }
 
-impl<U: User> PartialEq<LTerm<U>> for str {
-    fn eq(&self, other: &LTerm<U>) -> bool {
+impl<U, E> PartialEq<LTerm<U, E>> for str
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LTerm<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == self,
             _ => false,
@@ -650,7 +767,11 @@ impl<U: User> PartialEq<LTerm<U>> for str {
     }
 }
 
-impl<U: User> PartialEq<&str> for LTerm<U> {
+impl<U, E> PartialEq<&str> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &&str) -> bool {
         match self.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == other,
@@ -659,8 +780,12 @@ impl<U: User> PartialEq<&str> for LTerm<U> {
     }
 }
 
-impl<U: User> PartialEq<LTerm<U>> for &str {
-    fn eq(&self, other: &LTerm<U>) -> bool {
+impl<U, E> PartialEq<LTerm<U, E>> for &str
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn eq(&self, other: &LTerm<U, E>) -> bool {
         match other.as_ref() {
             LTermInner::Val(LValue::String(x)) => x == self,
             _ => false,
@@ -668,16 +793,28 @@ impl<U: User> PartialEq<LTerm<U>> for &str {
     }
 }
 
-impl<U: User> Eq for LTerm<U> {}
+impl<U, E> Eq for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{}
 
-impl<U: User> Default for LTerm<U> {
+impl<U, E> Default for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn default() -> Self {
         LTerm::from(LTermInner::Empty)
     }
 }
 
-impl<U: User> FromIterator<LTerm<U>> for LTerm<U> {
-    fn from_iter<T: IntoIterator<Item = LTerm<U>>>(iter: T) -> Self {
+impl<U, E> FromIterator<LTerm<U, E>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn from_iter<T: IntoIterator<Item = LTerm<U, E>>>(iter: T) -> Self {
         let mut list_head = LTerm::empty_list();
         let mut list_tail = &mut list_head;
         for elem in iter {
@@ -691,8 +828,12 @@ impl<U: User> FromIterator<LTerm<U>> for LTerm<U> {
     }
 }
 
-impl<U: User> Extend<LTerm<U>> for LTerm<U> {
-    fn extend<T: IntoIterator<Item = LTerm<U>>>(&mut self, coll: T) {
+impl<U, E> Extend<LTerm<U, E>> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn extend<T: IntoIterator<Item = LTerm<U, E>>>(&mut self, coll: T) {
         if !self.is_list() {
             panic!("Only list type (Empty or Cons) LTerms can be extended.");
         }
@@ -708,26 +849,38 @@ impl<U: User> Extend<LTerm<U>> for LTerm<U> {
         }
 
         // Swap in extension as new tail.
-        let mut extension: LTerm<U> = coll.into_iter().collect();
+        let mut extension: LTerm<U, E> = coll.into_iter().collect();
         std::mem::swap(tail.as_mut(), extension.as_mut());
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct LTermIter<'a, U: User> {
-    maybe_next: Option<&'a LTerm<U>>,
+pub struct LTermIter<'a, U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    maybe_next: Option<&'a LTerm<U, E>>,
 }
 
-impl<'a, U: User> LTermIter<'a, U> {
-    pub fn new(u: &'a LTerm<U>) -> LTermIter<'a, U> {
+impl<'a, U, E> LTermIter<'a, U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: &'a LTerm<U, E>) -> LTermIter<'a, U, E> {
         LTermIter {
             maybe_next: Some(u),
         }
     }
 }
 
-impl<'a, U: User> Iterator for LTermIter<'a, U> {
-    type Item = &'a LTerm<U>;
+impl<'a, U, E> Iterator for LTermIter<'a, U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    type Item = &'a LTerm<U, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Replace maybe_next in iterator with its tail and return head
@@ -755,32 +908,52 @@ impl<'a, U: User> Iterator for LTermIter<'a, U> {
     }
 }
 
-impl<'a, U: User> std::iter::FusedIterator for LTermIter<'a, U> {}
+impl<'a, U, E> std::iter::FusedIterator for LTermIter<'a, U, E>
+where
+    U: User,
+    E: Engine<U>,
+{}
 
-impl<'a, U: User> IntoIterator for &'a LTerm<U> {
-    type Item = &'a LTerm<U>;
-    type IntoIter = LTermIter<'a, U>;
+impl<'a, U, E> IntoIterator for &'a LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    type Item = &'a LTerm<U, E>;
+    type IntoIter = LTermIter<'a, U, E>;
 
-    fn into_iter(self) -> LTermIter<'a, U> {
+    fn into_iter(self) -> LTermIter<'a, U, E> {
         LTermIter::new(self)
     }
 }
 
 #[derive(Debug)]
-pub struct LTermIterMut<'a, U: User> {
-    maybe_next: Option<&'a mut LTerm<U>>,
+pub struct LTermIterMut<'a, U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    maybe_next: Option<&'a mut LTerm<U, E>>,
 }
 
-impl<'a, U: User> LTermIterMut<'a, U> {
-    pub fn new(u: &'a mut LTerm<U>) -> LTermIterMut<'a, U> {
+impl<'a, U, E> LTermIterMut<'a, U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: &'a mut LTerm<U, E>) -> LTermIterMut<'a, U, E> {
         LTermIterMut {
             maybe_next: Some(u),
         }
     }
 }
 
-impl<'a, U: User> Iterator for LTermIterMut<'a, U> {
-    type Item = &'a mut LTerm<U>;
+impl<'a, U, E> Iterator for LTermIterMut<'a, U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    type Item = &'a mut LTerm<U, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Replace maybe_next in iterator with its tail and return head
@@ -808,26 +981,42 @@ impl<'a, U: User> Iterator for LTermIterMut<'a, U> {
     }
 }
 
-impl<'a, U: User> IntoIterator for &'a mut LTerm<U> {
-    type Item = &'a mut LTerm<U>;
-    type IntoIter = LTermIterMut<'a, U>;
+impl<'a, U, E> IntoIterator for &'a mut LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    type Item = &'a mut LTerm<U, E>;
+    type IntoIter = LTermIterMut<'a, U, E>;
 
-    fn into_iter(self) -> LTermIterMut<'a, U> {
+    fn into_iter(self) -> LTermIterMut<'a, U, E> {
         LTermIterMut::new(self)
     }
 }
 
-impl<'a, U: User> std::iter::FusedIterator for LTermIterMut<'a, U> {}
+impl<'a, U, E> std::iter::FusedIterator for LTermIterMut<'a, U, E>
+where
+    U: User,
+    E: Engine<U>,
+{}
 
-impl<U: User> Index<usize> for LTerm<U> {
-    type Output = LTerm<U>;
+impl<U, E> Index<usize> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    type Output = LTerm<U, E>;
 
     fn index(&self, index: usize) -> &Self::Output {
         self.iter().nth(index).unwrap()
     }
 }
 
-impl<U: User> IndexMut<usize> for LTerm<U> {
+impl<U, E> IndexMut<usize> for LTerm<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         self.iter_mut().nth(index).unwrap()
     }
@@ -863,7 +1052,7 @@ mod test {
 
     #[test]
     fn test_lterm_val_1() {
-        let mut u: LTerm<EmptyUser> = lterm!(1);
+        let mut u: LTerm<EmptyUser, DefaultEngine<EmptyUser>> = lterm!(1);
         assert!(u.is_val());
         assert!(!u.is_var());
         assert!(!u.is_bool());

--- a/src/operator/all.rs
+++ b/src/operator/all.rs
@@ -78,7 +78,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         let stream = Stream::pause(Box::new(state), self.goal_1.clone());
         Stream::bind(stream, self.goal_2.clone())
     }

--- a/src/operator/any.rs
+++ b/src/operator/any.rs
@@ -61,7 +61,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         let stream = self.goal_1.solve(engine, state.clone());
         let lazy = LazyStream::pause(Box::new(state), self.goal_2.clone());
         Stream::mplus(stream, lazy)

--- a/src/operator/anyo.rs
+++ b/src/operator/anyo.rs
@@ -31,7 +31,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         let g = self.g.clone();
         let g2 = self.g.clone();
         let goal = proto_vulcan!(

--- a/src/operator/closure.rs
+++ b/src/operator/closure.rs
@@ -29,7 +29,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         (*self.f)().solve(engine, state)
     }
 }

--- a/src/operator/conda.rs
+++ b/src/operator/conda.rs
@@ -52,7 +52,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         let mut stream = self.first.solve(engine, state.clone());
 
         match stream.peek(engine) {

--- a/src/operator/conde.rs
+++ b/src/operator/conde.rs
@@ -46,7 +46,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         let mut stream = Stream::empty();
 
         // Process first element separately to avoid one extra clone of `state`.

--- a/src/operator/condu.rs
+++ b/src/operator/condu.rs
@@ -53,7 +53,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         let mut stream = self.first.solve(engine, state.clone());
 
         // Take only first item from the stream of first goal by truncating the stream

--- a/src/operator/everyg.rs
+++ b/src/operator/everyg.rs
@@ -13,10 +13,10 @@ where
     U: User,
     E: Engine<U>,
     T: Debug + 'static,
-    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U>>,
+    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U, E>>,
 {
     coll: T,
-    g: Box<dyn Fn(LTerm<U>) -> Goal<U, E>>,
+    g: Box<dyn Fn(LTerm<U, E>) -> Goal<U, E>>,
 }
 
 impl<T, U, E> Debug for Everyg<T, U, E>
@@ -24,7 +24,7 @@ where
     U: User,
     E: Engine<U>,
     T: Debug + 'static,
-    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U>>,
+    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U, E>>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Everyg()")
@@ -36,9 +36,9 @@ where
     U: User,
     E: Engine<U>,
     T: Debug + 'static,
-    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U>>,
+    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U, E>>,
 {
-    fn new(coll: T, g: Box<dyn Fn(LTerm<U>) -> Goal<U, E>>) -> Goal<U, E> {
+    fn new(coll: T, g: Box<dyn Fn(LTerm<U, E>) -> Goal<U, E>>) -> Goal<U, E> {
         Goal::new(Everyg { coll, g })
     }
 }
@@ -48,9 +48,9 @@ where
     U: User,
     E: Engine<U>,
     T: Debug + 'static,
-    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U>>,
+    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U, E>>,
 {
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         let term_iter = IntoIterator::into_iter(&self.coll);
         let goal_iter = term_iter.map(|term| (*self.g)(term.clone()));
         All::from_iter(goal_iter).solve(engine, state)
@@ -62,7 +62,7 @@ where
     E: Engine<U>,
     U: User,
     T: Debug + 'static,
-    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U>>,
+    for<'a> &'a T: IntoIterator<Item = &'a LTerm<U, E>>,
 {
     Everyg::new(param.coll, param.g)
 }

--- a/src/operator/fngoal.rs
+++ b/src/operator/fngoal.rs
@@ -11,7 +11,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    f: Box<dyn Fn(&E, State<U>) -> Stream<U, E>>,
+    f: Box<dyn Fn(&E, State<U, E>) -> Stream<U, E>>,
 }
 
 impl<U, E> FnGoal<U, E>
@@ -19,7 +19,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    pub fn new(f: Box<dyn Fn(&E, State<U>) -> Stream<U, E>>) -> Goal<U, E> {
+    pub fn new(f: Box<dyn Fn(&E, State<U, E>) -> Stream<U, E>>) -> Goal<U, E> {
         Goal::new(FnGoal { f })
     }
 }
@@ -29,7 +29,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         (*self.f)(engine, state)
     }
 }

--- a/src/operator/fresh.rs
+++ b/src/operator/fresh.rs
@@ -7,18 +7,18 @@ use crate::user::User;
 
 #[derive(Debug)]
 pub struct Fresh<E: Engine<U>, U: User> {
-    variables: Vec<LTerm<U>>,
+    variables: Vec<LTerm<U, E>>,
     body: Goal<U, E>,
 }
 
 impl<E: Engine<U>, U: User> Fresh<E, U> {
-    pub fn new(variables: Vec<LTerm<U>>, body: Goal<U, E>) -> Goal<U, E> {
+    pub fn new(variables: Vec<LTerm<U, E>>, body: Goal<U, E>) -> Goal<U, E> {
         Goal::new(Fresh { variables, body }) as Goal<U, E>
     }
 }
 
 impl<E: Engine<U>, U: User> Solve<U, E> for Fresh<E, U> {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         let goal = self.body.clone();
         Stream::pause(Box::new(state), goal)
     }

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -24,13 +24,13 @@ pub struct PatternMatchOperatorParam<'a, U: User, E: Engine<U>> {
 
 // project |x, y, ...| { <body> }
 pub struct ProjectOperatorParam<'a, U: User, E: Engine<U>> {
-    pub var_list: Vec<LTerm<U>>,
+    pub var_list: Vec<LTerm<U, E>>,
     pub body: &'a [&'a [Goal<U, E>]],
 }
 
 // fngoal [move]* |engine, state| { <rust> }
 pub struct FnOperatorParam<U: User, E: Engine<U>> {
-    pub f: Box<dyn Fn(&E, State<U>) -> Stream<U, E>>,
+    pub f: Box<dyn Fn(&E, State<U, E>) -> Stream<U, E>>,
 }
 
 // closure { <body> }
@@ -44,12 +44,12 @@ where
     E: Engine<U>,
     U: User,
     T: Debug + 'static,
-    for<'b> &'b T: IntoIterator<Item = &'b LTerm<U>>,
+    for<'b> &'b T: IntoIterator<Item = &'b LTerm<U, E>>,
 {
     pub coll: T,
     // Goal generator: generates a goal for each cycle of the "loop" given element from the
     // collection.
-    pub g: Box<dyn Fn(LTerm<U>) -> Goal<U, E>>,
+    pub g: Box<dyn Fn(LTerm<U, E>) -> Goal<U, E>>,
 }
 
 #[doc(hidden)]

--- a/src/operator/project.rs
+++ b/src/operator/project.rs
@@ -13,7 +13,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    variables: Vec<LTerm<U>>,
+    variables: Vec<LTerm<U, E>>,
     body: Goal<U, E>,
 }
 
@@ -22,7 +22,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    pub fn new(variables: Vec<LTerm<U>>, body: Goal<U, E>) -> Goal<U, E> {
+    pub fn new(variables: Vec<LTerm<U, E>>, body: Goal<U, E>) -> Goal<U, E> {
         Goal::new(Project { variables, body }) as Goal<U, E>
     }
 }
@@ -32,7 +32,7 @@ where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
         // Walk* each projected variable with the current substitution
         for v in self.variables.iter() {
             v.project(|x| state.smap_ref().walk_star(x));
@@ -57,23 +57,23 @@ mod tests {
     use crate::prelude::*;
 
     #[derive(Debug)]
-    pub struct SqEq<U: User> {
-        u: LTerm<U>,
-        v: LTerm<U>,
+    pub struct SqEq<U: User, E: Engine<U>> {
+        u: LTerm<U, E>,
+        v: LTerm<U, E>,
     }
 
-    impl<U: User> SqEq<U> {
-        pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E> {
+    impl<U: User, E: Engine<U>> SqEq<U, E> {
+        pub fn new(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E> {
             Goal::new(SqEq { u, v })
         }
     }
 
-    impl<U, E> Solve<U, E> for SqEq<U>
+    impl<U, E> Solve<U, E> for SqEq<U, E>
     where
         U: User,
         E: Engine<U>,
     {
-        fn solve(&self, engine: &E, state: State<U>) -> Stream<U, E> {
+        fn solve(&self, engine: &E, state: State<U, E>) -> Stream<U, E> {
             let u = self.u.clone();
             let v = self.v.clone();
             let g: Goal<U, E> = proto_vulcan!(fngoal move |_engine, state| {
@@ -91,7 +91,7 @@ mod tests {
         }
     }
 
-    fn sqeq<U, E>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E>
+    fn sqeq<U, E>(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E>
     where
         U: User,
         E: Engine<U>,

--- a/src/query.rs
+++ b/src/query.rs
@@ -9,21 +9,22 @@ use std::iter::FusedIterator;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-pub trait QueryResult<U = EmptyUser>
+pub trait QueryResult<U = EmptyUser, E = DefaultEngine<U>>
 where
     U: User,
+    E: Engine<U>,
 {
-    fn from_vec(v: Vec<LResult<U>>) -> Self;
+    fn from_vec(v: Vec<LResult<U, E>>) -> Self;
 }
 
 pub struct ResultIterator<R, U = EmptyUser, E = DefaultEngine<U>>
 where
-    R: QueryResult<U>,
+    R: QueryResult<U, E>,
     U: User,
     E: Engine<U>,
 {
     engine: E,
-    variables: Vec<LTerm<U>>,
+    variables: Vec<LTerm<U, E>>,
     stream: Stream<U, E>,
     _phantom: PhantomData<R>,
 }
@@ -31,15 +32,15 @@ where
 #[doc(hidden)]
 impl<R, U, E> ResultIterator<R, U, E>
 where
-    R: QueryResult<U>,
+    R: QueryResult<U, E>,
     U: User,
     E: Engine<U>,
 {
     pub fn new(
         engine: E,
-        variables: Vec<LTerm<U>>,
+        variables: Vec<LTerm<U, E>>,
         goal: Goal<U, E>,
-        initial_state: State<U>,
+        initial_state: State<U, E>,
     ) -> ResultIterator<R, U, E> {
         let stream = goal.solve(&engine, initial_state);
         ResultIterator {
@@ -54,7 +55,7 @@ where
 #[doc(hidden)]
 impl<R, U, E> Iterator for ResultIterator<R, U, E>
 where
-    R: QueryResult<U>,
+    R: QueryResult<U, E>,
     U: User,
     E: Engine<U>,
 {
@@ -71,8 +72,9 @@ where
                 let results = self
                     .variables
                     .iter()
-                    .map(|v| LResult(state.smap_ref().walk_star(v), Rc::clone(&reified_cstore)))
+                    .map(|v| LResult::<U, E>(state.smap_ref().walk_star(v), Rc::clone(&reified_cstore)))
                     .collect();
+                
                 Some(R::from_vec(results))
             }
             None => None,
@@ -84,7 +86,7 @@ where
 #[doc(hidden)]
 impl<R, U, E> FusedIterator for ResultIterator<R, U, E>
 where
-    R: QueryResult<U>,
+    R: QueryResult<U, E>,
     U: User,
     E: Engine<U>,
 {
@@ -94,18 +96,18 @@ where
 #[derivative(Debug)]
 pub struct Query<R, U = EmptyUser, E = DefaultEngine<U>>
 where
-    R: QueryResult<U>,
+    R: QueryResult<U, E>,
     U: User,
     E: Engine<U>,
 {
-    variables: Vec<LTerm<U>>,
+    variables: Vec<LTerm<U, E>>,
     goal: Goal<U, E>,
     _phantom: std::marker::PhantomData<R>,
 }
 
 impl<R, E> Query<R, EmptyUser, E>
 where
-    R: QueryResult<EmptyUser>,
+    R: QueryResult<EmptyUser, E>,
     E: Engine<EmptyUser>,
 {
     pub fn run(&self) -> ResultIterator<R, EmptyUser, E> {
@@ -117,11 +119,11 @@ where
 
 impl<R, U, E> Query<R, U, E>
 where
-    R: QueryResult<U>,
+    R: QueryResult<U, E>,
     U: User,
     E: Engine<U>,
 {
-    pub fn new(variables: Vec<LTerm<U>>, goal: Goal<U, E>) -> Query<R, U, E> {
+    pub fn new(variables: Vec<LTerm<U, E>>, goal: Goal<U, E>) -> Query<R, U, E> {
         Query {
             variables,
             goal,

--- a/src/query.rs
+++ b/src/query.rs
@@ -4,12 +4,12 @@ use crate::lresult::LResult;
 use crate::lterm::LTerm;
 use crate::state::State;
 use crate::stream::Stream;
-use crate::user::{EmptyUser, User};
+use crate::user::{DefaultUser, User};
 use std::iter::FusedIterator;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-pub trait QueryResult<U = EmptyUser, E = DefaultEngine<U>>
+pub trait QueryResult<U = DefaultUser, E = DefaultEngine<U>>
 where
     U: User,
     E: Engine<U>,
@@ -17,7 +17,7 @@ where
     fn from_vec(v: Vec<LResult<U, E>>) -> Self;
 }
 
-pub struct ResultIterator<R, U = EmptyUser, E = DefaultEngine<U>>
+pub struct ResultIterator<R, U = DefaultUser, E = DefaultEngine<U>>
 where
     R: QueryResult<U, E>,
     U: User,
@@ -94,7 +94,7 @@ where
 
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct Query<R, U = EmptyUser, E = DefaultEngine<U>>
+pub struct Query<R, U = DefaultUser, E = DefaultEngine<U>>
 where
     R: QueryResult<U, E>,
     U: User,
@@ -105,13 +105,13 @@ where
     _phantom: std::marker::PhantomData<R>,
 }
 
-impl<R, E> Query<R, EmptyUser, E>
+impl<R, E> Query<R, DefaultUser, E>
 where
-    R: QueryResult<EmptyUser, E>,
-    E: Engine<EmptyUser>,
+    R: QueryResult<DefaultUser, E>,
+    E: Engine<DefaultUser>,
 {
-    pub fn run(&self) -> ResultIterator<R, EmptyUser, E> {
-        let user_state = EmptyUser::new();
+    pub fn run(&self) -> ResultIterator<R, DefaultUser, E> {
+        let user_state = DefaultUser::new();
         let user_globals = ();
         self.run_with_user(user_state, user_globals)
     }

--- a/src/relation/appendo.rs
+++ b/src/relation/appendo.rs
@@ -16,7 +16,7 @@ use crate::user::User;
 ///     });
 ///     assert!(query.run().next().unwrap().q == lterm!([1, 2, 3, 4, 5]));
 /// }
-pub fn appendo<U, E>(l: LTerm<U>, s: LTerm<U>, ls: LTerm<U>) -> Goal<U, E>
+pub fn appendo<U, E>(l: LTerm<U, E>, s: LTerm<U, E>, ls: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/conso.rs
+++ b/src/relation/conso.rs
@@ -18,7 +18,7 @@ use crate::user::User;
 ///     assert!(query.run().next().unwrap().q == lterm!([1, 2, 3]));
 /// }
 /// ```
-pub fn conso<U, E>(first: LTerm<U>, rest: LTerm<U>, out: LTerm<U>) -> Goal<U, E>
+pub fn conso<U, E>(first: LTerm<U, E>, rest: LTerm<U, E>, out: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/diseq.rs
+++ b/src/relation/diseq.rs
@@ -185,8 +185,8 @@ mod tests {
         smap.extend(x.clone(), five.clone());
         let c1 = DisequalityConstraint::new(smap);
         match (
-            c0.downcast_ref::<DisequalityConstraint<EmptyUser, DefaultEngine<EmptyUser>>>(),
-            c1.downcast_ref::<DisequalityConstraint<EmptyUser, DefaultEngine<EmptyUser>>>(),
+            c0.downcast_ref::<DisequalityConstraint<DefaultUser, DefaultEngine<DefaultUser>>>(),
+            c1.downcast_ref::<DisequalityConstraint<DefaultUser, DefaultEngine<DefaultUser>>>(),
         ) {
             (Some(t0), Some(t1)) => {
                 assert!(t1.subsumes(&*t0))

--- a/src/relation/diseq.rs
+++ b/src/relation/diseq.rs
@@ -7,23 +7,31 @@ use crate::user::User;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct Diseq<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-}
-
-impl<U: User> Diseq<U> {
-    pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E> {
-        Goal::new(Diseq { u, v })
-    }
-}
-
-impl<U, E> Solve<U, E> for Diseq<U>
+pub struct Diseq<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+}
+
+impl<U, E> Diseq<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E> {
+        Goal::new(Diseq { u, v })
+    }
+}
+
+impl<U, E> Solve<U, E> for Diseq<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         // Return state where u and v are unified under s, or None if unification is not possible
         match state.disunify(&self.u, &self.v) {
             Ok(state) => Stream::unit(Box::new(state)),
@@ -55,7 +63,7 @@ where
 ///     assert!(iter.next().is_none());
 /// }
 /// ```
-pub fn diseq<U, E>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E>
+pub fn diseq<U, E>(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,
@@ -64,11 +72,16 @@ where
 }
 
 // Disequality constraint
-#[derive(Clone, Debug)]
-pub struct DisequalityConstraint<U: User>(SMap<U>);
+#[derive(Derivative, Debug)]
+#[derivative(Clone(bound="U: User"))]
+pub struct DisequalityConstraint<U: User, E: Engine<U>>(SMap<U, E>);
 
-impl<U: User> DisequalityConstraint<U> {
-    pub fn new(smap: SMap<U>) -> Rc<dyn Constraint<U>> {
+impl<U, E> DisequalityConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(smap: SMap<U, E>) -> Rc<dyn Constraint<U, E>> {
         Rc::new(DisequalityConstraint(smap))
     }
 
@@ -76,7 +89,7 @@ impl<U: User> DisequalityConstraint<U> {
     ///
     /// A constraint is subsumed by another constraint if unifying the constraint in the
     /// substitution of the another constraint does not extend the constraint.
-    pub fn subsumes(&self, other: &dyn Constraint<U>) -> bool {
+    pub fn subsumes(&self, other: &dyn Constraint<U, E>) -> bool {
         match other.downcast_ref::<Self>() {
             Some(other) => {
                 let mut extension = SMap::new();
@@ -94,11 +107,11 @@ impl<U: User> DisequalityConstraint<U> {
         }
     }
 
-    pub fn smap_ref(&self) -> &SMap<U> {
+    pub fn smap_ref(&self) -> &SMap<U, E> {
         &self.0
     }
 
-    pub fn walk_star(&self, smap: &SMap<U>) -> SMap<U> {
+    pub fn walk_star(&self, smap: &SMap<U, E>) -> SMap<U, E> {
         let mut n = SMap::new();
         for (k, v) in self.smap_ref().iter() {
             let kwalk = smap.walk_star(k);
@@ -110,8 +123,12 @@ impl<U: User> DisequalityConstraint<U> {
     }
 }
 
-impl<U: User> Constraint<U> for DisequalityConstraint<U> {
-    fn run(self: Rc<Self>, state: State<U>) -> SResult<U> {
+impl<U, E> Constraint<U, E> for DisequalityConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn run(self: Rc<Self>, state: State<U, E>) -> SResult<U, E> {
         let mut extension = SMap::new();
         let mut test_state = state.clone();
         for (u, v) in self.0.iter() {
@@ -129,12 +146,16 @@ impl<U: User> Constraint<U> for DisequalityConstraint<U> {
         }
     }
 
-    fn operands(&self) -> Vec<LTerm<U>> {
+    fn operands(&self) -> Vec<LTerm<U, E>> {
         self.0.operands()
     }
 }
 
-impl<U: User> std::fmt::Display for DisequalityConstraint<U> {
+impl<U, E> std::fmt::Display for DisequalityConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         for (u, v) in self.0.iter() {
             write!(f, "{} != {},", u, v)?;
@@ -147,6 +168,7 @@ impl<U: User> std::fmt::Display for DisequalityConstraint<U> {
 mod tests {
     use super::*;
     use crate::prelude::*;
+    use crate::engine::DefaultEngine;
 
     #[test]
     fn test_subsumes_1() {
@@ -163,8 +185,8 @@ mod tests {
         smap.extend(x.clone(), five.clone());
         let c1 = DisequalityConstraint::new(smap);
         match (
-            c0.downcast_ref::<DisequalityConstraint<EmptyUser>>(),
-            c1.downcast_ref::<DisequalityConstraint<EmptyUser>>(),
+            c0.downcast_ref::<DisequalityConstraint<EmptyUser, DefaultEngine<EmptyUser>>>(),
+            c1.downcast_ref::<DisequalityConstraint<EmptyUser, DefaultEngine<EmptyUser>>>(),
         ) {
             (Some(t0), Some(t1)) => {
                 assert!(t1.subsumes(&*t0))

--- a/src/relation/diseqfd.rs
+++ b/src/relation/diseqfd.rs
@@ -9,23 +9,31 @@ use crate::user::User;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct DiseqFd<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-}
-
-impl<U: User> DiseqFd<U> {
-    pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E> {
-        Goal::new(DiseqFd { u, v })
-    }
-}
-
-impl<U, E> Solve<U, E> for DiseqFd<U>
+pub struct DiseqFd<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+}
+
+impl<U, E> DiseqFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E> {
+        Goal::new(DiseqFd { u, v })
+    }
+}
+
+impl<U, E> Solve<U, E> for DiseqFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         let u = self.u.clone();
         let v = self.v.clone();
         match DiseqFdConstraint::new(u, v).run(state) {
@@ -62,7 +70,7 @@ where
 ///     assert_eq!(expected.len(), 0);
 /// }
 /// ```
-pub fn diseqfd<U, E>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E>
+pub fn diseqfd<U, E>(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,
@@ -71,21 +79,33 @@ where
 }
 
 #[derive(Debug)]
-pub struct DiseqFdConstraint<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
+pub struct DiseqFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
 }
 
-impl<U: User> DiseqFdConstraint<U> {
-    pub fn new(u: LTerm<U>, v: LTerm<U>) -> Rc<dyn Constraint<U>> {
+impl<U, E> DiseqFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>) -> Rc<dyn Constraint<U, E>> {
         assert!(u.is_var() || u.is_number());
         assert!(v.is_var() || v.is_number());
         Rc::new(DiseqFdConstraint { u, v })
     }
 }
 
-impl<U: User> Constraint<U> for DiseqFdConstraint<U> {
-    fn run(self: Rc<Self>, state: State<U>) -> SResult<U> {
+impl<U, E> Constraint<U, E> for DiseqFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn run(self: Rc<Self>, state: State<U, E>) -> SResult<U, E> {
         let smap = state.get_smap();
         let dstore = state.get_dstore();
 
@@ -149,12 +169,16 @@ impl<U: User> Constraint<U> for DiseqFdConstraint<U> {
         }
     }
 
-    fn operands(&self) -> Vec<LTerm<U>> {
+    fn operands(&self) -> Vec<LTerm<U, E>> {
         vec![self.u.clone(), self.v.clone()]
     }
 }
 
-impl<U: User> std::fmt::Display for DiseqFdConstraint<U> {
+impl<U, E> std::fmt::Display for DiseqFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "")
     }

--- a/src/relation/distincto.rs
+++ b/src/relation/distincto.rs
@@ -4,7 +4,7 @@ use crate::lterm::LTerm;
 use crate::user::User;
 
 /// A relation which guarantees that all elements of `l` are distinct from each other.
-pub fn distincto<U, E>(l: LTerm<U>) -> Goal<U, E>
+pub fn distincto<U, E>(l: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/domfd.rs
+++ b/src/relation/domfd.rs
@@ -9,13 +9,21 @@ use crate::user::User;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct DomFd<U: User> {
-    x: LTerm<U>,
+pub struct DomFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    x: LTerm<U, E>,
     domain: Rc<FiniteDomain>,
 }
 
-impl<U: User> DomFd<U> {
-    pub fn new<E: Engine<U>>(x: LTerm<U>, domain: FiniteDomain) -> Goal<U, E> {
+impl<U, E> DomFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(x: LTerm<U, E>, domain: FiniteDomain) -> Goal<U, E> {
         Goal::new(DomFd {
             x,
             domain: Rc::new(domain),
@@ -23,12 +31,12 @@ impl<U: User> DomFd<U> {
     }
 }
 
-impl<U, E> Solve<U, E> for DomFd<U>
+impl<U, E> Solve<U, E> for DomFd<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         let xwalk = state.smap_ref().walk(&self.x).clone();
         match state.process_domain(&xwalk, Rc::clone(&self.domain) as Rc<FiniteDomain>) {
             Ok(state) => Stream::unit(Box::new(state)),

--- a/src/relation/emptyo.rs
+++ b/src/relation/emptyo.rs
@@ -19,7 +19,7 @@ use crate::user::User;
 ///     assert!(query.run().next().unwrap().q == lterm!([]));
 /// }
 /// ```
-pub fn emptyo<U, E>(s: LTerm<U>) -> Goal<U, E>
+pub fn emptyo<U, E>(s: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/eq.rs
+++ b/src/relation/eq.rs
@@ -6,23 +6,31 @@ use crate::stream::Stream;
 use crate::user::User;
 
 #[derive(Debug)]
-pub struct Eq<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-}
-
-impl<U: User> Eq<U> {
-    pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E> {
-        Goal::new(Eq { u, v })
-    }
-}
-
-impl<U, E> Solve<U, E> for Eq<U>
+pub struct Eq<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+}
+
+impl<U, E> Eq<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E> {
+        Goal::new(Eq { u, v })
+    }
+}
+
+impl<U, E> Solve<U, E> for Eq<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         match state.unify(&self.u, &self.v) {
             Ok(state) => Stream::unit(Box::new(state)),
             Err(_) => Stream::empty(),
@@ -49,7 +57,7 @@ where
 ///     assert!(iter.next().is_none());
 /// }
 /// ```
-pub fn eq<U, E>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E>
+pub fn eq<U, E>(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/firsto.rs
+++ b/src/relation/firsto.rs
@@ -5,7 +5,7 @@ use crate::relation::conso;
 use crate::user::User;
 
 /// A relation such that the `first` is the first element of `list`.
-pub fn firsto<U, E>(list: LTerm<U>, first: LTerm<U>) -> Goal<U, E>
+pub fn firsto<U, E>(list: LTerm<U, E>, first: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/infd.rs
+++ b/src/relation/infd.rs
@@ -8,7 +8,7 @@ use crate::user::User;
 use std::ops::RangeInclusive;
 
 /// Associates the same domain to multiple variables
-pub fn infd<U, E>(u: LTerm<U>, domain: &[isize]) -> Goal<U, E>
+pub fn infd<U, E>(u: LTerm<U, E>, domain: &[isize]) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,
@@ -24,7 +24,7 @@ where
     }
 }
 
-pub fn infdrange<U, E>(u: LTerm<U>, domain: &RangeInclusive<isize>) -> Goal<U, E>
+pub fn infdrange<U, E>(u: LTerm<U, E>, domain: &RangeInclusive<isize>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/ltefd.rs
+++ b/src/relation/ltefd.rs
@@ -8,23 +8,31 @@ use crate::user::User;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct LessThanOrEqualFd<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-}
-
-impl<U: User> LessThanOrEqualFd<U> {
-    pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E> {
-        Goal::new(LessThanOrEqualFd { u, v })
-    }
-}
-
-impl<U, E> Solve<U, E> for LessThanOrEqualFd<U>
+pub struct LessThanOrEqualFd<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+}
+
+impl<U, E> LessThanOrEqualFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E> {
+        Goal::new(LessThanOrEqualFd { u, v })
+    }
+}
+
+impl<U, E> Solve<U, E> for LessThanOrEqualFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         match LessThanOrEqualFdConstraint::new(self.u.clone(), self.v.clone()).run(state) {
             Ok(state) => Stream::unit(Box::new(state)),
             Err(_) => Stream::empty(),
@@ -32,7 +40,7 @@ where
     }
 }
 
-pub fn ltefd<U, E>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E>
+pub fn ltefd<U, E>(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,
@@ -42,21 +50,33 @@ where
 
 // Finite Domain Constraints
 #[derive(Debug, Clone)]
-pub struct LessThanOrEqualFdConstraint<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
+pub struct LessThanOrEqualFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
 }
 
-impl<U: User> LessThanOrEqualFdConstraint<U> {
-    pub fn new(u: LTerm<U>, v: LTerm<U>) -> Rc<dyn Constraint<U>> {
+impl<U, E> LessThanOrEqualFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>) -> Rc<dyn Constraint<U, E>> {
         assert!(u.is_var() || u.is_number());
         assert!(v.is_var() || v.is_number());
         Rc::new(LessThanOrEqualFdConstraint { u, v })
     }
 }
 
-impl<U: User> Constraint<U> for LessThanOrEqualFdConstraint<U> {
-    fn run(self: Rc<Self>, state: State<U>) -> SResult<U> {
+impl<U, E> Constraint<U, E> for LessThanOrEqualFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn run(self: Rc<Self>, state: State<U, E>) -> SResult<U, E> {
         let smap = state.get_smap();
         let dstore = state.get_dstore();
 
@@ -120,12 +140,16 @@ impl<U: User> Constraint<U> for LessThanOrEqualFdConstraint<U> {
         }
     }
 
-    fn operands(&self) -> Vec<LTerm<U>> {
+    fn operands(&self) -> Vec<LTerm<U, E>> {
         vec![self.u.clone(), self.v.clone()]
     }
 }
 
-impl<U: User> std::fmt::Display for LessThanOrEqualFdConstraint<U> {
+impl<U, E> std::fmt::Display for LessThanOrEqualFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "")
     }

--- a/src/relation/ltfd.rs
+++ b/src/relation/ltfd.rs
@@ -6,7 +6,7 @@ use crate::relation::diseqfd::diseqfd;
 use crate::relation::ltefd::ltefd;
 use crate::user::User;
 
-pub fn ltfd<U, E>(u: LTerm<U>, v: LTerm<U>) -> Goal<U, E>
+pub fn ltfd<U, E>(u: LTerm<U, E>, v: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/member1o.rs
+++ b/src/relation/member1o.rs
@@ -19,7 +19,7 @@ use crate::user::User;
 ///     assert!(iter.next().is_none());
 /// }
 /// ```
-pub fn member1o<U, E>(x: LTerm<U>, l: LTerm<U>) -> Goal<U, E>
+pub fn member1o<U, E>(x: LTerm<U, E>, l: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/membero.rs
+++ b/src/relation/membero.rs
@@ -21,7 +21,7 @@ use crate::user::User;
 ///     assert!(iter.next().is_none());
 /// }
 /// ```
-pub fn membero<U, E>(x: LTerm<U>, l: LTerm<U>) -> Goal<U, E>
+pub fn membero<U, E>(x: LTerm<U, E>, l: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/minusfd.rs
+++ b/src/relation/minusfd.rs
@@ -9,24 +9,32 @@ use crate::user::User;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct MinusFd<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
-}
-
-impl<U: User> MinusFd<U> {
-    pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E> {
-        Goal::new(MinusFd { u, v, w })
-    }
-}
-
-impl<U, E> Solve<U, E> for MinusFd<U>
+pub struct MinusFd<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
+}
+
+impl<U, E> MinusFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E> {
+        Goal::new(MinusFd { u, v, w })
+    }
+}
+
+impl<U, E> Solve<U, E> for MinusFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         match MinusFdConstraint::new(self.u.clone(), self.v.clone(), self.w.clone()).run(state) {
             Ok(state) => Stream::unit(Box::new(state)),
             Err(_) => Stream::empty(),
@@ -34,7 +42,7 @@ where
     }
 }
 
-pub fn minusfd<U, E>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E>
+pub fn minusfd<U, E>(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,
@@ -43,14 +51,22 @@ where
 }
 
 #[derive(Debug)]
-pub struct MinusFdConstraint<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
+pub struct MinusFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
 }
 
-impl<U: User> MinusFdConstraint<U> {
-    pub fn new(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Rc<dyn Constraint<U>> {
+impl<U, E> MinusFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Rc<dyn Constraint<U, E>> {
         assert!(u.is_var() || u.is_number());
         assert!(v.is_var() || v.is_number());
         assert!(w.is_var() || w.is_number());
@@ -58,8 +74,12 @@ impl<U: User> MinusFdConstraint<U> {
     }
 }
 
-impl<U: User> Constraint<U> for MinusFdConstraint<U> {
-    fn run(self: Rc<Self>, state: State<U>) -> SResult<U> {
+impl<U, E> Constraint<U, E> for MinusFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn run(self: Rc<Self>, state: State<U, E>) -> SResult<U, E> {
         let smap = state.get_smap();
         let dstore = state.get_dstore();
 
@@ -155,12 +175,16 @@ impl<U: User> Constraint<U> for MinusFdConstraint<U> {
         }
     }
 
-    fn operands(&self) -> Vec<LTerm<U>> {
+    fn operands(&self) -> Vec<LTerm<U, E>> {
         vec![self.u.clone(), self.v.clone(), self.w.clone()]
     }
 }
 
-impl<U: User> std::fmt::Display for MinusFdConstraint<U> {
+impl<U, E> std::fmt::Display for MinusFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "")
     }

--- a/src/relation/permuteo.rs
+++ b/src/relation/permuteo.rs
@@ -5,7 +5,7 @@ use crate::relation::rembero;
 use crate::user::User;
 
 /// A relation that will permute xl into yl.
-pub fn permuteo<U, E>(xl: LTerm<U>, yl: LTerm<U>) -> Goal<U, E>
+pub fn permuteo<U, E>(xl: LTerm<U, E>, yl: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/plusfd.rs
+++ b/src/relation/plusfd.rs
@@ -9,24 +9,32 @@ use crate::user::User;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct PlusFd<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
-}
-
-impl<U: User> PlusFd<U> {
-    pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E> {
-        Goal::new(PlusFd { u, v, w })
-    }
-}
-
-impl<U, E> Solve<U, E> for PlusFd<U>
+pub struct PlusFd<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
+}
+
+impl<U, E> PlusFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E> {
+        Goal::new(PlusFd { u, v, w })
+    }
+}
+
+impl<U, E> Solve<U, E> for PlusFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         match PlusFdConstraint::new(self.u.clone(), self.v.clone(), self.w.clone()).run(state) {
             Ok(state) => Stream::unit(Box::new(state)),
             Err(_) => Stream::empty(),
@@ -34,7 +42,7 @@ where
     }
 }
 
-pub fn plusfd<U, E>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E>
+pub fn plusfd<U, E>(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,
@@ -43,14 +51,22 @@ where
 }
 
 #[derive(Debug)]
-pub struct PlusFdConstraint<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
+pub struct PlusFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
 }
 
-impl<U: User> PlusFdConstraint<U> {
-    pub fn new(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Rc<dyn Constraint<U>> {
+impl<U, E> PlusFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Rc<dyn Constraint<U, E>> {
         assert!(u.is_var() || u.is_number());
         assert!(v.is_var() || v.is_number());
         assert!(w.is_var() || w.is_number());
@@ -58,8 +74,12 @@ impl<U: User> PlusFdConstraint<U> {
     }
 }
 
-impl<U: User> Constraint<U> for PlusFdConstraint<U> {
-    fn run(self: Rc<Self>, state: State<U>) -> SResult<U> {
+impl<U, E> Constraint<U, E> for PlusFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn run(self: Rc<Self>, state: State<U, E>) -> SResult<U, E> {
         let smap = state.get_smap();
         let dstore = state.get_dstore();
 
@@ -152,12 +172,16 @@ impl<U: User> Constraint<U> for PlusFdConstraint<U> {
         }
     }
 
-    fn operands(&self) -> Vec<LTerm<U>> {
+    fn operands(&self) -> Vec<LTerm<U, E>> {
         vec![self.u.clone(), self.v.clone(), self.w.clone()]
     }
 }
 
-impl<U: User> std::fmt::Display for PlusFdConstraint<U> {
+impl<U, E> std::fmt::Display for PlusFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "")
     }

--- a/src/relation/plusz.rs
+++ b/src/relation/plusz.rs
@@ -9,24 +9,32 @@ use crate::user::User;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct PlusZ<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
-}
-
-impl<U: User> PlusZ<U> {
-    pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E> {
-        Goal::new(PlusZ { u, v, w })
-    }
-}
-
-impl<U, E> Solve<U, E> for PlusZ<U>
+pub struct PlusZ<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
+}
+
+impl<U, E> PlusZ<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E> {
+        Goal::new(PlusZ { u, v, w })
+    }
+}
+
+impl<U, E> Solve<U, E> for PlusZ<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         match PlusZConstraint::new(self.u.clone(), self.v.clone(), self.w.clone()).run(state) {
             Ok(state) => Stream::unit(Box::new(state)),
             Err(_) => Stream::empty(),
@@ -34,7 +42,7 @@ where
     }
 }
 
-pub fn plusz<U, E>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E>
+pub fn plusz<U, E>(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,
@@ -44,14 +52,22 @@ where
 
 /// Sum
 #[derive(Debug, Clone)]
-pub struct PlusZConstraint<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
+pub struct PlusZConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
 }
 
-impl<U: User> PlusZConstraint<U> {
-    pub fn new(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Rc<dyn Constraint<U>> {
+impl<U, E> PlusZConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Rc<dyn Constraint<U, E>> {
         assert!(u.is_var() || u.is_number());
         assert!(v.is_var() || v.is_number());
         assert!(w.is_var() || w.is_number());
@@ -59,8 +75,12 @@ impl<U: User> PlusZConstraint<U> {
     }
 }
 
-impl<U: User> Constraint<U> for PlusZConstraint<U> {
-    fn run(self: Rc<Self>, mut state: State<U>) -> SResult<U> {
+impl<U, E> Constraint<U, E> for PlusZConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn run(self: Rc<Self>, mut state: State<U, E>) -> SResult<U, E> {
         let uwalk = state.smap_ref().walk(&self.u).clone();
         let vwalk = state.smap_ref().walk(&self.v).clone();
         let wwalk = state.smap_ref().walk(&self.w).clone();
@@ -124,12 +144,16 @@ impl<U: User> Constraint<U> for PlusZConstraint<U> {
         }
     }
 
-    fn operands(&self) -> Vec<LTerm<U>> {
+    fn operands(&self) -> Vec<LTerm<U, E>> {
         vec![self.u.clone(), self.v.clone(), self.w.clone()]
     }
 }
 
-impl<U: User> std::fmt::Display for PlusZConstraint<U> {
+impl<U, E> std::fmt::Display for PlusZConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "")
     }

--- a/src/relation/rembero.rs
+++ b/src/relation/rembero.rs
@@ -17,7 +17,7 @@ use crate::user::User;
 ///     assert!(query.run().next().unwrap().q == lterm!([1, 3, 2, 4]));
 /// }
 /// ```
-pub fn rembero<U, E>(x: LTerm<U>, ls: LTerm<U>, out: LTerm<U>) -> Goal<U, E>
+pub fn rembero<U, E>(x: LTerm<U, E>, ls: LTerm<U, E>, out: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/resto.rs
+++ b/src/relation/resto.rs
@@ -18,7 +18,7 @@ use crate::user::User;
 ///     assert!(query.run().next().unwrap().q == lterm!([2, 3]));
 /// }
 /// ```
-pub fn resto<U, E>(list: LTerm<U>, rest: LTerm<U>) -> Goal<U, E>
+pub fn resto<U, E>(list: LTerm<U, E>, rest: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,

--- a/src/relation/timesfd.rs
+++ b/src/relation/timesfd.rs
@@ -9,24 +9,32 @@ use crate::user::User;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct TimesFd<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
-}
-
-impl<U: User> TimesFd<U> {
-    pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E> {
-        Goal::new(TimesFd { u, v, w })
-    }
-}
-
-impl<U, E> Solve<U, E> for TimesFd<U>
+pub struct TimesFd<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
+}
+
+impl<U, E> TimesFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E> {
+        Goal::new(TimesFd { u, v, w })
+    }
+}
+
+impl<U, E> Solve<U, E> for TimesFd<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         match TimesFdConstraint::new(self.u.clone(), self.v.clone(), self.w.clone()).run(state) {
             Ok(state) => Stream::unit(Box::new(state)),
             Err(_) => Stream::empty(),
@@ -34,7 +42,7 @@ where
     }
 }
 
-pub fn timesfd<U, E>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E>
+pub fn timesfd<U, E>(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,
@@ -43,14 +51,22 @@ where
 }
 
 #[derive(Debug)]
-pub struct TimesFdConstraint<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
+pub struct TimesFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
 }
 
-impl<U: User> TimesFdConstraint<U> {
-    pub fn new(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Rc<dyn Constraint<U>> {
+impl<U, E> TimesFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Rc<dyn Constraint<U, E>> {
         assert!(u.is_var() || u.is_number());
         assert!(v.is_var() || v.is_number());
         assert!(w.is_var() || w.is_number());
@@ -58,8 +74,12 @@ impl<U: User> TimesFdConstraint<U> {
     }
 }
 
-impl<U: User> Constraint<U> for TimesFdConstraint<U> {
-    fn run(self: Rc<Self>, state: State<U>) -> SResult<U> {
+impl<U, E> Constraint<U, E> for TimesFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn run(self: Rc<Self>, state: State<U, E>) -> SResult<U, E> {
         let smap = state.get_smap();
         let dstore = state.get_dstore();
 
@@ -157,12 +177,16 @@ impl<U: User> Constraint<U> for TimesFdConstraint<U> {
         }
     }
 
-    fn operands(&self) -> Vec<LTerm<U>> {
+    fn operands(&self) -> Vec<LTerm<U, E>> {
         vec![self.u.clone(), self.v.clone(), self.w.clone()]
     }
 }
 
-impl<U: User> std::fmt::Display for TimesFdConstraint<U> {
+impl<U, E> std::fmt::Display for TimesFdConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "")
     }

--- a/src/relation/timesz.rs
+++ b/src/relation/timesz.rs
@@ -9,24 +9,32 @@ use crate::user::User;
 use std::rc::Rc;
 
 #[derive(Debug)]
-pub struct TimesZ<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
-}
-
-impl<U: User> TimesZ<U> {
-    pub fn new<E: Engine<U>>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E> {
-        Goal::new(TimesZ { u, v, w })
-    }
-}
-
-impl<U, E> Solve<U, E> for TimesZ<U>
+pub struct TimesZ<U, E>
 where
     U: User,
     E: Engine<U>,
 {
-    fn solve(&self, _engine: &E, state: State<U>) -> Stream<U, E> {
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
+}
+
+impl<U, E> TimesZ<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E> {
+        Goal::new(TimesZ { u, v, w })
+    }
+}
+
+impl<U, E> Solve<U, E> for TimesZ<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn solve(&self, _engine: &E, state: State<U, E>) -> Stream<U, E> {
         match TimesZConstraint::new(self.u.clone(), self.v.clone(), self.w.clone()).run(state) {
             Ok(state) => Stream::unit(Box::new(state)),
             Err(_) => Stream::empty(),
@@ -34,7 +42,7 @@ where
     }
 }
 
-pub fn timesz<U, E>(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Goal<U, E>
+pub fn timesz<U, E>(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Goal<U, E>
 where
     U: User,
     E: Engine<U>,
@@ -43,14 +51,22 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct TimesZConstraint<U: User> {
-    u: LTerm<U>,
-    v: LTerm<U>,
-    w: LTerm<U>,
+pub struct TimesZConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    u: LTerm<U, E>,
+    v: LTerm<U, E>,
+    w: LTerm<U, E>,
 }
 
-impl<U: User> TimesZConstraint<U> {
-    pub fn new(u: LTerm<U>, v: LTerm<U>, w: LTerm<U>) -> Rc<dyn Constraint<U>> {
+impl<U, E> TimesZConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new(u: LTerm<U, E>, v: LTerm<U, E>, w: LTerm<U, E>) -> Rc<dyn Constraint<U, E>> {
         assert!(u.is_var() || u.is_number());
         assert!(v.is_var() || v.is_number());
         assert!(w.is_var() || w.is_number());
@@ -58,8 +74,12 @@ impl<U: User> TimesZConstraint<U> {
     }
 }
 
-impl<U: User> Constraint<U> for TimesZConstraint<U> {
-    fn run(self: Rc<Self>, mut state: State<U>) -> SResult<U> {
+impl<U, E> Constraint<U, E> for TimesZConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn run(self: Rc<Self>, mut state: State<U, E>) -> SResult<U, E> {
         let uwalk = state.smap_ref().walk(&self.u).clone();
         let vwalk = state.smap_ref().walk(&self.v).clone();
         let wwalk = state.smap_ref().walk(&self.w).clone();
@@ -123,12 +143,16 @@ impl<U: User> Constraint<U> for TimesZConstraint<U> {
         }
     }
 
-    fn operands(&self) -> Vec<LTerm<U>> {
+    fn operands(&self) -> Vec<LTerm<U, E>> {
         vec![self.u.clone(), self.v.clone(), self.w.clone()]
     }
 }
 
-impl<U: User> std::fmt::Display for TimesZConstraint<U> {
+impl<U, E> std::fmt::Display for TimesZConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "")
     }

--- a/src/state/constraint/mod.rs
+++ b/src/state/constraint/mod.rs
@@ -1,3 +1,4 @@
+use crate::engine::Engine;
 use super::substitution::SMap;
 use super::{SResult, State, User};
 use crate::lterm::LTerm;
@@ -9,21 +10,34 @@ use std::rc::Rc;
 
 pub mod store;
 
-pub trait Constraint<U: User>: Debug + Display + AnyConstraint<U> {
-    fn run(self: Rc<Self>, state: State<U>) -> SResult<U>;
+pub trait Constraint<U, E>: Debug + Display + AnyConstraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    fn run(self: Rc<Self>, state: State<U, E>) -> SResult<U, E>;
 
-    fn reify(&self, _state: &mut State<U>) {}
+    fn reify(&self, _state: &mut State<U, E>) {}
 
-    fn operands(&self) -> Vec<LTerm<U>>;
+    fn operands(&self) -> Vec<LTerm<U, E>>;
 }
 
-pub trait AnyConstraint<U>: Any {
+pub trait AnyConstraint<U, E>: Any
+where
+    U: User,
+    E: Engine<U>,
+{
     fn as_any(&self) -> &dyn Any;
 
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
-impl<T: Constraint<U>, U: User> AnyConstraint<U> for T {
+impl<U, E, T> AnyConstraint<U, E> for T
+where
+    U: User,
+    E: Engine<U>,
+    T: Constraint<U, E>,
+{
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -33,33 +47,49 @@ impl<T: Constraint<U>, U: User> AnyConstraint<U> for T {
     }
 }
 
-impl<U: User> dyn Constraint<U> {
+impl<U, E> dyn Constraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     #[inline]
-    pub fn is<T: Constraint<U>>(&self) -> bool {
+    pub fn is<T: Constraint<U, E>>(&self) -> bool {
         TypeId::of::<T>() == self.type_id()
     }
 
     #[inline]
-    pub fn downcast_ref<T: Any + Constraint<U>>(&self) -> Option<&T> {
+    pub fn downcast_ref<T: Any + Constraint<U, E>>(&self) -> Option<&T> {
         self.as_any().downcast_ref::<T>()
     }
 
     #[inline]
-    pub fn downcast_mut<T: Constraint<U>>(&mut self) -> Option<&mut T> {
+    pub fn downcast_mut<T: Constraint<U, E>>(&mut self) -> Option<&mut T> {
         self.as_any_mut().downcast_mut::<T>()
     }
 }
 
-impl<U: User> Hash for dyn Constraint<U> {
+impl<U, E> Hash for dyn Constraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         ptr::hash(self as *const Self, state)
     }
 }
 
-impl<U: User> PartialEq for dyn Constraint<U> {
+impl<U, E> PartialEq for dyn Constraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     fn eq(&self, other: &Self) -> bool {
         ptr::eq(self, other)
     }
 }
 
-impl<U: User> Eq for dyn Constraint<U> {}
+impl<U, E> Eq for dyn Constraint<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{}

--- a/src/state/constraint/store.rs
+++ b/src/state/constraint/store.rs
@@ -2,15 +2,24 @@ use super::SMap;
 use crate::lterm::LTerm;
 use crate::relation::diseq::DisequalityConstraint;
 use crate::state::constraint::Constraint;
+use crate::engine::Engine;
 use crate::state::User;
 use std::collections::HashSet;
 use std::rc::Rc;
 
-#[derive(Clone, Debug)]
-pub struct ConstraintStore<U: User>(HashSet<Rc<dyn Constraint<U>>>);
+#[derive(Derivative, Debug)]
+#[derivative(Clone(bound="U: User"))]
+pub struct ConstraintStore<U, E>(HashSet<Rc<dyn Constraint<U, E>>>)
+where
+    U: User,
+    E: Engine<U>;
 
-impl<U: User> ConstraintStore<U> {
-    pub fn new() -> ConstraintStore<U> {
+impl<U, E> ConstraintStore<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    pub fn new() -> ConstraintStore<U, E> {
         ConstraintStore(HashSet::new())
     }
 
@@ -20,10 +29,10 @@ impl<U: User> ConstraintStore<U> {
     /// substitution map. Unassociated variables can be Var(_) or Any. Associated variables are
     /// already fully constrained by the values they are associated with, whereas unassociated
     /// variables are constrained by the constraints.
-    pub fn purify(self, r: &SMap<U>) -> ConstraintStore<U> {
+    pub fn purify(self, r: &SMap<U, E>) -> ConstraintStore<U, E> {
         let mut purified_cstore = ConstraintStore::new();
         for constraint in self.0.into_iter() {
-            if let Some(tree_constraint) = constraint.downcast_ref::<DisequalityConstraint<U>>() {
+            if let Some(tree_constraint) = constraint.downcast_ref::<DisequalityConstraint<U, E>>() {
                 if tree_constraint
                     .smap_ref()
                     .iter()
@@ -39,10 +48,10 @@ impl<U: User> ConstraintStore<U> {
     }
 
     /// Do walk_star for each substitution of each constraint
-    pub fn walk_star(&self, smap: &SMap<U>) -> ConstraintStore<U> {
+    pub fn walk_star(&self, smap: &SMap<U, E>) -> ConstraintStore<U, E> {
         let mut walked_cstore = ConstraintStore::new();
         for constraint in self.iter() {
-            if let Some(tree_constraint) = constraint.downcast_ref::<DisequalityConstraint<U>>() {
+            if let Some(tree_constraint) = constraint.downcast_ref::<DisequalityConstraint<U, E>>() {
                 let ws = tree_constraint.walk_star(smap);
                 let c = DisequalityConstraint::new(ws);
                 walked_cstore.insert(c);
@@ -52,12 +61,12 @@ impl<U: User> ConstraintStore<U> {
     }
 
     /// Add new constraint `c` while keeping the store normalized
-    pub fn push_and_normalize(&mut self, newc: Rc<dyn Constraint<U>>) {
-        if let Some(tree_newc) = newc.downcast_ref::<DisequalityConstraint<U>>() {
+    pub fn push_and_normalize(&mut self, newc: Rc<dyn Constraint<U, E>>) {
+        if let Some(tree_newc) = newc.downcast_ref::<DisequalityConstraint<U, E>>() {
             let mut normalized = HashSet::new();
             for storec in self.0.drain() {
                 // All non-subsumable constraints are always carried along
-                if let Some(tree_storec) = storec.downcast_ref::<DisequalityConstraint<U>>() {
+                if let Some(tree_storec) = storec.downcast_ref::<DisequalityConstraint<U, E>>() {
                     if !tree_storec.subsumes(tree_newc) && !tree_newc.subsumes(tree_storec) {
                         normalized.insert(storec);
                     }
@@ -71,7 +80,7 @@ impl<U: User> ConstraintStore<U> {
     }
 
     /// Remove redundant constraints from the store
-    pub fn normalize(self) -> ConstraintStore<U> {
+    pub fn normalize(self) -> ConstraintStore<U, E> {
         let mut normalized_store = ConstraintStore::new();
         for storec in self.0.into_iter() {
             normalized_store.push_and_normalize(storec.into());
@@ -79,11 +88,11 @@ impl<U: User> ConstraintStore<U> {
         normalized_store
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Rc<dyn Constraint<U>>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = &Rc<dyn Constraint<U, E>>> + '_ {
         self.0.iter()
     }
 
-    pub fn into_iter(self) -> impl Iterator<Item = Rc<dyn Constraint<U>>> {
+    pub fn into_iter(self) -> impl Iterator<Item = Rc<dyn Constraint<U, E>>> {
         self.0.into_iter()
     }
 
@@ -91,19 +100,19 @@ impl<U: User> ConstraintStore<U> {
         self.0.is_empty()
     }
 
-    pub fn take(&mut self, u: &Rc<dyn Constraint<U>>) -> Option<Rc<dyn Constraint<U>>> {
+    pub fn take(&mut self, u: &Rc<dyn Constraint<U, E>>) -> Option<Rc<dyn Constraint<U, E>>> {
         self.0.take(u)
     }
 
-    pub fn insert(&mut self, key: Rc<dyn Constraint<U>>) -> bool {
+    pub fn insert(&mut self, key: Rc<dyn Constraint<U, E>>) -> bool {
         self.0.insert(key)
     }
 
     /// Iterate over constraints that refer to terms in `u`
     pub fn relevant<'a>(
         &'a self,
-        relevant_operands: &Vec<LTerm<U>>,
-    ) -> impl Iterator<Item = &'a Rc<dyn Constraint<U>>> {
+        relevant_operands: &Vec<LTerm<U, E>>,
+    ) -> impl Iterator<Item = &'a Rc<dyn Constraint<U, E>>> {
         let relevant_operands = relevant_operands.clone();
         self.iter().filter(move |c| {
             c.operands()
@@ -112,11 +121,11 @@ impl<U: User> ConstraintStore<U> {
         })
     }
 
-    pub fn display_relevant(&self, u: &LTerm<U>, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    pub fn display_relevant(&self, u: &LTerm<U, E>, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let anyvars = u.anyvars();
         let mut count = 0;
         for storec in self.relevant(&anyvars) {
-            if let Some(treec) = storec.downcast_ref::<DisequalityConstraint<U>>() {
+            if let Some(treec) = storec.downcast_ref::<DisequalityConstraint<U, E>>() {
                 // Tree-disequality constraint has a substitution map that may have
                 // multiple disequality sub-constraints. Each disequality is printed
                 // here separately if it is relevant to the given operands.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,7 +1,7 @@
 use crate::lterm::{LTerm, LTermInner};
 use crate::lvalue::LValue;
 use crate::relation::diseq::DisequalityConstraint;
-use crate::user::{User, EmptyUser};
+use crate::user::{User, DefaultUser};
 use crate::engine::{Engine, DefaultEngine};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -40,7 +40,7 @@ pub type SResult<U, E> = Result<State<U, E>, ()>;
 ///    4. User data
 #[derive(Derivative, Debug)]
 #[derivative(Clone(bound="U: User"))]
-pub struct State<U = EmptyUser, E = DefaultEngine<EmptyUser>>
+pub struct State<U = DefaultUser, E = DefaultEngine<DefaultUser>>
 where
     U: User,
     E: Engine<U>,

--- a/src/state/substitution.rs
+++ b/src/state/substitution.rs
@@ -226,19 +226,19 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::user::EmptyUser;
+    use crate::user::DefaultUser;
     use crate::engine::DefaultEngine;
 
     #[test]
     fn test_smap_new() {
-        let smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         // A newly created SMap is empty
         assert!(smap.is_empty());
     }
 
     #[test]
     fn test_smap_extend() {
-        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let mut smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v = lterm!(_);
         let t = lterm!(1234);
 
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_smap_occurs_check_1() {
-        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let mut smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn test_smap_occurs_check_2() {
-        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let mut smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -295,7 +295,7 @@ mod tests {
     #[test]
     fn test_smap_walk_1() {
         // 1. Variable not found in map => input returned back as it is impossible to walk
-        let smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v = lterm!(_);
         let w = smap.walk(&v);
         assert!(LTerm::ptr_eq(&v, &w));
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn test_smap_walk_2() {
         // 2. Variable found => walked until no more variables: ends in last variable
-        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let mut smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn test_smap_walk_3() {
         // 2. Variable found => walked until no more variables: ends in last value
-        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let mut smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -337,7 +337,7 @@ mod tests {
     fn test_smap_walk_4() {
         // 2. Variable found => walked until no more variables: ends in last list and does not
         //    recurse into the list.
-        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let mut smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn test_smap_walk_star_1() {
         // 1. Variable not found in map => input returned back as it is impossible to walk
-        let smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v = lterm!(_);
         let w = smap.walk_star(&v);
         assert!(LTerm::ptr_eq(&v, &w));
@@ -366,7 +366,7 @@ mod tests {
     #[test]
     fn test_smap_walk_star_2() {
         // 2. Variable found => walked until no more variables: ends in last variable
-        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let mut smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn test_smap_walk_star_3() {
         // 2. Variable found => walked until no more variables: ends in last value
-        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let mut smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -399,7 +399,7 @@ mod tests {
     fn test_smap_walk_star_4() {
         // 2. Variable found => walked until no more variables: ends in last list and does
         //    recurse into the list.
-        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let mut smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn test_smap_reify() {
-        let smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
+        let smap = SMap::<DefaultUser, DefaultEngine<DefaultUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v = LTerm::cons(v0.clone(), LTerm::singleton(v1.clone()));

--- a/src/state/substitution.rs
+++ b/src/state/substitution.rs
@@ -1,25 +1,32 @@
 use crate::compound::CompoundObject;
 use crate::lterm::{LTerm, LTermInner};
-use crate::user::{EmptyUser, User};
+use crate::user::User;
+use crate::engine::Engine;
 use std::collections::HashMap;
 use std::ops::Deref;
 
 /// Substitution Map
 ///
 /// Substitution maps track the binding of variables to terms.
-#[derive(Clone, Debug)]
-pub struct SMap<U = EmptyUser>(HashMap<LTerm<U>, LTerm<U>>)
+#[derive(Derivative, Debug)]
+#[derivative(Clone(bound="U: User"))]
+pub struct SMap<U, E>(HashMap<LTerm<U, E>, LTerm<U, E>>)
 where
-    U: User;
+    U: User,
+    E: Engine<U>;
 
-impl<U: User> SMap<U> {
+impl<U, E> SMap<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     /// Construct an an empty substitution map with no substitutions
-    pub fn new() -> SMap<U> {
+    pub fn new() -> SMap<U, E> {
         SMap(HashMap::new())
     }
 
     /// Extend substitution map with a new substitution
-    pub fn extend(&mut self, k: LTerm<U>, v: LTerm<U>) {
+    pub fn extend(&mut self, k: LTerm<U, E>, v: LTerm<U, E>) {
         self.0.insert(k, v);
     }
 
@@ -31,7 +38,7 @@ impl<U: User> SMap<U> {
     ///
     /// Walking the substitution map recursively traverses the map until no next term is found,
     /// or the term found is a non-variable.
-    pub fn walk<'a>(&'a self, mut k: &'a LTerm<U>) -> &'a LTerm<U> {
+    pub fn walk<'a>(&'a self, mut k: &'a LTerm<U, E>) -> &'a LTerm<U, E> {
         loop {
             match k.as_ref() {
                 LTermInner::Var(_, _) => {
@@ -47,7 +54,7 @@ impl<U: User> SMap<U> {
 
     /// Alternative walk of the substitution map that does not bind the return value lifetime
     /// to lifetime of the input variable `k`.
-    pub fn walk_if<'a, 'b>(&'a self, k: &'b LTerm<U>) -> Option<&'a LTerm<U>> {
+    pub fn walk_if<'a, 'b>(&'a self, k: &'b LTerm<U, E>) -> Option<&'a LTerm<U, E>> {
         if k.is_var() {
             // First step
             let mut step = match self.0.get(k) {
@@ -75,7 +82,7 @@ impl<U: User> SMap<U> {
     /// Walks the substitution map recursively like `walk()`, but does not stop at lists, and
     /// instead recurses to do the deep walk also for the list elements. Returns a term which
     /// is a tree where all leaves are walked terms.
-    pub fn walk_star(&self, v: &LTerm<U>) -> LTerm<U> {
+    pub fn walk_star(&self, v: &LTerm<U, E>) -> LTerm<U, E> {
         let v = self.walk(v);
         match v.as_ref() {
             LTermInner::Cons(head, tail) => LTerm::cons(self.walk_star(head), self.walk_star(tail)),
@@ -85,7 +92,7 @@ impl<U: User> SMap<U> {
     }
 
     /// Check that the variable `x` is not contained in the compound object `compound`.
-    fn occurs_check_compound(&self, x: &LTerm<U>, compound: &dyn CompoundObject<U>) -> bool {
+    fn occurs_check_compound(&self, x: &LTerm<U, E>, compound: &dyn CompoundObject<U, E>) -> bool {
         compound.children().any(|child| match child.as_term() {
             Some(v) => self.occurs_check(x, v),
             None => self.occurs_check_compound(x, child),
@@ -96,7 +103,7 @@ impl<U: User> SMap<U> {
     ///
     /// Occurs check is used to prevent unification of terms that would cause the variable to
     /// be contained in itself.
-    pub fn occurs_check(&self, x: &LTerm<U>, v: &LTerm<U>) -> bool {
+    pub fn occurs_check(&self, x: &LTerm<U, E>, v: &LTerm<U, E>) -> bool {
         match self.walk(v).as_ref() {
             LTermInner::Var(vvar, _) => match x.as_ref() {
                 LTermInner::Var(xvar, _) => *vvar == *xvar,
@@ -110,7 +117,7 @@ impl<U: User> SMap<U> {
         }
     }
 
-    fn reify_compound(&self, compound: &dyn CompoundObject<U>) -> SMap<U> {
+    fn reify_compound(&self, compound: &dyn CompoundObject<U, E>) -> SMap<U, E> {
         let mut smap = self.clone();
         for child in compound.children() {
             match child.as_term() {
@@ -130,7 +137,7 @@ impl<U: User> SMap<U> {
     ///
     /// This is typically used to generate a reifying substitution map from an empty map. The
     /// reifying map maps free variables to reified names. See State::reify().
-    pub fn reify(&self, v: &LTerm<U>) -> SMap<U> {
+    pub fn reify(&self, v: &LTerm<U, E>) -> SMap<U, E> {
         let walkv = self.walk(v);
         match walkv.as_ref() {
             LTermInner::Var(_, _) => {
@@ -146,7 +153,7 @@ impl<U: User> SMap<U> {
         }
     }
 
-    fn is_anyvar_compound(&self, compound: &dyn CompoundObject<U>) -> bool {
+    fn is_anyvar_compound(&self, compound: &dyn CompoundObject<U, E>) -> bool {
         compound.children().any(|child| match child.as_term() {
             Some(v) => self.is_anyvar(v),
             None => self.is_anyvar_compound(child),
@@ -154,7 +161,7 @@ impl<U: User> SMap<U> {
     }
 
     /// Check if the given logic term refers to any unassociated variables
-    pub fn is_anyvar(&self, v: &LTerm<U>) -> bool {
+    pub fn is_anyvar(&self, v: &LTerm<U, E>) -> bool {
         match v.as_ref() {
             LTermInner::Var(_, _) if self.contains_key(v) => {
                 let walkv = self.walk(&v);
@@ -167,7 +174,7 @@ impl<U: User> SMap<U> {
     }
 
     /// Returns a list of variables referenced by the substitution map
-    pub fn get_vars(&self) -> Vec<&LTerm<U>> {
+    pub fn get_vars(&self) -> Vec<&LTerm<U, E>> {
         let mut vars = vec![];
         for (k, v) in self.0.iter() {
             vars.push(k);
@@ -179,7 +186,7 @@ impl<U: User> SMap<U> {
     }
 
     /// Returns a set of variables operands referencesd by the substitution
-    pub fn operands(&self) -> Vec<LTerm<U>> {
+    pub fn operands(&self) -> Vec<LTerm<U, E>> {
         let mut operands = vec![];
         for (k, v) in self.0.iter() {
             operands.push(k.clone());
@@ -191,17 +198,25 @@ impl<U: User> SMap<U> {
     }
 }
 
-impl<U: User> IntoIterator for SMap<U> {
-    type Item = (LTerm<U>, LTerm<U>);
-    type IntoIter = ::std::collections::hash_map::IntoIter<LTerm<U>, LTerm<U>>;
+impl<U, E> IntoIterator for SMap<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    type Item = (LTerm<U, E>, LTerm<U, E>);
+    type IntoIter = ::std::collections::hash_map::IntoIter<LTerm<U, E>, LTerm<U, E>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl<U: User> Deref for SMap<U> {
-    type Target = HashMap<LTerm<U>, LTerm<U>>;
+impl<U, E> Deref for SMap<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
+    type Target = HashMap<LTerm<U, E>, LTerm<U, E>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -211,17 +226,19 @@ impl<U: User> Deref for SMap<U> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::user::EmptyUser;
+    use crate::engine::DefaultEngine;
 
     #[test]
     fn test_smap_new() {
-        let smap = SMap::<EmptyUser>::new();
+        let smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         // A newly created SMap is empty
         assert!(smap.is_empty());
     }
 
     #[test]
     fn test_smap_extend() {
-        let mut smap = SMap::<EmptyUser>::new();
+        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v = lterm!(_);
         let t = lterm!(1234);
 
@@ -237,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_smap_occurs_check_1() {
-        let mut smap = SMap::<EmptyUser>::new();
+        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -256,7 +273,7 @@ mod tests {
 
     #[test]
     fn test_smap_occurs_check_2() {
-        let mut smap = SMap::<EmptyUser>::new();
+        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -278,7 +295,7 @@ mod tests {
     #[test]
     fn test_smap_walk_1() {
         // 1. Variable not found in map => input returned back as it is impossible to walk
-        let smap = SMap::<EmptyUser>::new();
+        let smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v = lterm!(_);
         let w = smap.walk(&v);
         assert!(LTerm::ptr_eq(&v, &w));
@@ -287,7 +304,7 @@ mod tests {
     #[test]
     fn test_smap_walk_2() {
         // 2. Variable found => walked until no more variables: ends in last variable
-        let mut smap = SMap::<EmptyUser>::new();
+        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -302,7 +319,7 @@ mod tests {
     #[test]
     fn test_smap_walk_3() {
         // 2. Variable found => walked until no more variables: ends in last value
-        let mut smap = SMap::<EmptyUser>::new();
+        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -320,7 +337,7 @@ mod tests {
     fn test_smap_walk_4() {
         // 2. Variable found => walked until no more variables: ends in last list and does not
         //    recurse into the list.
-        let mut smap = SMap::<EmptyUser>::new();
+        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -340,7 +357,7 @@ mod tests {
     #[test]
     fn test_smap_walk_star_1() {
         // 1. Variable not found in map => input returned back as it is impossible to walk
-        let smap = SMap::<EmptyUser>::new();
+        let smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v = lterm!(_);
         let w = smap.walk_star(&v);
         assert!(LTerm::ptr_eq(&v, &w));
@@ -349,7 +366,7 @@ mod tests {
     #[test]
     fn test_smap_walk_star_2() {
         // 2. Variable found => walked until no more variables: ends in last variable
-        let mut smap = SMap::<EmptyUser>::new();
+        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -364,7 +381,7 @@ mod tests {
     #[test]
     fn test_smap_walk_star_3() {
         // 2. Variable found => walked until no more variables: ends in last value
-        let mut smap = SMap::<EmptyUser>::new();
+        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -382,7 +399,7 @@ mod tests {
     fn test_smap_walk_star_4() {
         // 2. Variable found => walked until no more variables: ends in last list and does
         //    recurse into the list.
-        let mut smap = SMap::<EmptyUser>::new();
+        let mut smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v2 = lterm!(_);
@@ -406,7 +423,7 @@ mod tests {
 
     #[test]
     fn test_smap_reify() {
-        let smap = SMap::<EmptyUser>::new();
+        let smap = SMap::<EmptyUser, DefaultEngine<EmptyUser>>::new();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
         let v = LTerm::cons(v0.clone(), LTerm::singleton(v1.clone()));

--- a/src/state/unification.rs
+++ b/src/state/unification.rs
@@ -2,15 +2,20 @@ use super::substitution::SMap;
 use crate::compound::CompoundObject;
 use crate::lterm::{LTerm, LTermInner};
 use crate::state::{SResult, State};
+use crate::engine::Engine;
 use crate::user::User;
 
 /// Recursive unification of tree terms
-pub fn unify_rec<U: User>(
-    mut state: State<U>,
-    extension: &mut SMap<U>,
-    u: &LTerm<U>,
-    v: &LTerm<U>,
-) -> SResult<U> {
+pub fn unify_rec<U, E>(
+    mut state: State<U, E>,
+    extension: &mut SMap<U, E>,
+    u: &LTerm<U, E>,
+    v: &LTerm<U, E>,
+) -> SResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     let uwalk = state.smap_ref().walk(u).clone();
     let vwalk = state.smap_ref().walk(v).clone();
     match (uwalk.as_ref(), vwalk.as_ref()) {
@@ -63,12 +68,16 @@ pub fn unify_rec<U: User>(
 }
 
 /// Recursive unification of compound terms
-fn unify_rec_compound<U: User>(
-    mut state: State<U>,
-    extension: &mut SMap<U>,
-    ucompound: &dyn CompoundObject<U>,
-    vcompound: &dyn CompoundObject<U>,
-) -> SResult<U> {
+fn unify_rec_compound<U, E>(
+    mut state: State<U, E>,
+    extension: &mut SMap<U, E>,
+    ucompound: &dyn CompoundObject<U, E>,
+    vcompound: &dyn CompoundObject<U, E>,
+) -> SResult<U, E>
+where
+    U: User,
+    E: Engine<U>,
+{
     if ucompound.type_id() != vcompound.type_id() {
         return Err(());
     }
@@ -97,12 +106,13 @@ fn unify_rec_compound<U: User>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::DefaultEngine;
     use crate::prelude::*;
 
     #[test]
     fn test_unify_1() {
         // 1. var == var
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -121,7 +131,7 @@ mod tests {
     #[test]
     fn test_unify_2() {
         // 2. var != var
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -140,7 +150,7 @@ mod tests {
     #[test]
     fn test_unify_3() {
         // 3. var == val
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -165,7 +175,7 @@ mod tests {
     #[test]
     fn test_unify_4() {
         // 4. var == list
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -190,7 +200,7 @@ mod tests {
     #[test]
     fn test_unify_5() {
         // 5. val == var
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -215,7 +225,7 @@ mod tests {
     #[test]
     fn test_unify_6() {
         // 6. list == var
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);

--- a/src/state/unification.rs
+++ b/src/state/unification.rs
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn test_unify_1() {
         // 1. var == var
-        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
+        let mut state = State::<DefaultUser, DefaultEngine<DefaultUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn test_unify_2() {
         // 2. var != var
-        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
+        let mut state = State::<DefaultUser, DefaultEngine<DefaultUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn test_unify_3() {
         // 3. var == val
-        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
+        let mut state = State::<DefaultUser, DefaultEngine<DefaultUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -175,7 +175,7 @@ mod tests {
     #[test]
     fn test_unify_4() {
         // 4. var == list
-        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
+        let mut state = State::<DefaultUser, DefaultEngine<DefaultUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -200,7 +200,7 @@ mod tests {
     #[test]
     fn test_unify_5() {
         // 5. val == var
-        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
+        let mut state = State::<DefaultUser, DefaultEngine<DefaultUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn test_unify_6() {
         // 6. list == var
-        let mut state = State::<EmptyUser, DefaultEngine<EmptyUser>>::new(Default::default());
+        let mut state = State::<DefaultUser, DefaultEngine<DefaultUser>>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(_);
         let v1 = lterm!(_);
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn test_unify_7() {
         // 7. val == val
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<DefaultUser>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(1);
         let v1 = lterm!(_);
@@ -268,7 +268,7 @@ mod tests {
     #[test]
     fn test_unify_8() {
         // 8. val != val
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<DefaultUser>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!(1);
         let v1 = lterm!(_);
@@ -286,7 +286,7 @@ mod tests {
     #[test]
     fn test_unify_9() {
         // 9. list[N] == list[N]
-        let state = State::<EmptyUser>::new(Default::default());
+        let state = State::<DefaultUser>::new(Default::default());
         let v0 = lterm!([1]);
         let v1 = lterm!([1]);
 
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn test_unify_10() {
         // 10. list[N] != list[N]
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<DefaultUser>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!([1]);
         let v1 = lterm!(_);
@@ -317,7 +317,7 @@ mod tests {
     #[test]
     fn test_unify_11() {
         // 11. list[N] != list[M] where N != M
-        let mut state = State::<EmptyUser>::new(Default::default());
+        let mut state = State::<DefaultUser>::new(Default::default());
         let smap = state.smap_to_mut();
         let v0 = lterm!([1 | 1]);
         let v1 = lterm!(_);
@@ -335,7 +335,7 @@ mod tests {
     #[test]
     fn test_unify_12() {
         // Occurs check 1
-        let state = State::<EmptyUser>::new(Default::default());
+        let state = State::<DefaultUser>::new(Default::default());
         let u = LTerm::var("u");
         let v = lterm!([1, 2, 3, u]);
 
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn test_unify_13() {
         // Occurs check 2
-        let state = State::<EmptyUser>::new(Default::default());
+        let state = State::<DefaultUser>::new(Default::default());
         let u = LTerm::var("u");
         let v = lterm!([1, 2, 3, u]);
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -48,27 +48,27 @@ pub trait User: Debug + Clone + Default + 'static {
 }
 
 #[derive(Debug, Clone)]
-pub struct EmptyUser {}
+pub struct DefaultUser {}
 
-impl EmptyUser {
-    pub fn new() -> EmptyUser {
-        EmptyUser {}
+impl DefaultUser {
+    pub fn new() -> DefaultUser {
+        DefaultUser {}
     }
 }
 
-impl fmt::Display for EmptyUser {
+impl fmt::Display for DefaultUser {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "")
     }
 }
 
-impl Default for EmptyUser {
-    fn default() -> EmptyUser {
-        EmptyUser {}
+impl Default for DefaultUser {
+    fn default() -> DefaultUser {
+        DefaultUser {}
     }
 }
 
-impl User for EmptyUser {
+impl User for DefaultUser {
     type UserTerm = ();
     type UserContext = ();
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -16,35 +16,35 @@ pub trait User: Debug + Clone + Default + 'static {
     type UserContext: Debug;
 
     /// Process extension to substitution map.
-    fn process_extension(state: State<Self>, _extension: &SMap<Self>) -> SResult<Self> {
+    fn process_extension<E: Engine<Self>>(state: State<Self, E>, _extension: &SMap<Self, E>) -> SResult<Self, E> {
         Ok(state)
     }
 
     // User unification.
-    fn unify(
-        _state: State<Self>,
-        _extension: &mut SMap<Self>,
-        _uwalk: LTerm<Self>,
-        _vwalk: LTerm<Self>,
-    ) -> SResult<Self> {
+    fn unify<E: Engine<Self>>(
+        _state: State<Self, E>,
+        _extension: &mut SMap<Self, E>,
+        _uwalk: LTerm<Self, E>,
+        _vwalk: LTerm<Self, E>,
+    ) -> SResult<Self, E> {
         Err(())
     }
 
     /// Called before the constraint is added to the state
-    fn with_constraint(_state: &mut State<Self>, _constraint: &Rc<dyn Constraint<Self>>) {}
+    fn with_constraint<E: Engine<Self>>(_state: &mut State<Self, E>, _constraint: &Rc<dyn Constraint<Self, E>>) {}
 
     /// Called after the constraint has been removed from the state
-    fn take_constraint(_state: &mut State<Self>, _constraint: &Rc<dyn Constraint<Self>>) {}
+    fn take_constraint<E: Engine<Self>>(_state: &mut State<Self, E>, _constraint: &Rc<dyn Constraint<Self, E>>) {}
 
     /// Called in reification when constraints are finalized. For example finite domain
     /// constraints are converted to sequences of integers.
-    fn enforce_constraints<E: Engine<Self>>(_x: LTerm<Self>) -> Goal<Self, E> {
+    fn enforce_constraints<E: Engine<Self>>(_x: LTerm<Self, E>) -> Goal<Self, E> {
         proto_vulcan!(true)
     }
 
-    fn finalize(_state: &mut State<Self>) {}
+    fn finalize<E: Engine<Self>>(_state: &mut State<Self, E>) {}
 
-    fn reify(_state: &mut State<Self>) {}
+    fn reify<E: Engine<Self>>(_state: &mut State<Self, E>) {}
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR adds Engine type parameter to LTerm and many other types to make everything in proto-vulcan engine-specific.

Closes #1.