### PR TITLE
Fix UB in LTerm::project

### DIFF
--- a/src/lterm.rs
+++ b/src/lterm.rs
@@ -136,12 +136,9 @@ where
     {
         match self.as_ref() {
             LTermInner::Projection(p) => {
-                let ptr: *const LTermInner<U, E> = self.inner.as_ref();
+                let ptr = Rc::as_ptr(&self.inner) as *mut LTermInner<U, E>;
                 let projected = f(p).into_inner();
-                let _ = unsafe {
-                    let mut_ptr = ptr as *mut LTermInner<U, E>;
-                    std::ptr::replace(mut_ptr, projected.as_ref().clone())
-                };
+                unsafe { *ptr = projected.as_ref().clone() };
             }
             _ => panic!("Cannot project non-Projection LTerm."),
         }


### PR DESCRIPTION
Running the current tests under miri shows that there is Undefined Behavior in `LTerm::project`:
```rs
error: Undefined Behavior: trying to reborrow <8513993> for Unique permission at alloc3303876[0x10], but that tag only grants SharedReadOnly permission for this location
   --> src/lterm.rs:143:21
    |
143 |                     std::ptr::replace(mut_ptr, projected.as_ref().clone())
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

That's because `self.inner.as_ref()` creates an intermediate **shared** reference that cannot be written to. However it is then cast to `*mut LTermInner<U, E>` and then written to by a `ptr::replace`.

Using `Rc::as_ptr` creates no such intermediate reference to the value inside of the `Rc<T>` and directly goes to a raw pointer, and raw pointers do not have these strict rules.